### PR TITLE
Updated dropdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-bootstrap-navwalker
 ======================
 
-A custom WordPress nav walker class to implement the Twitter Bootstrap 2.3.2 (https://github.com/twitter/bootstrap/) navigation style in a custom theme using the WordPress built in menu manager.
+A custom WordPress nav walker class to implement the Twitter Bootstrap 2.3.2 (and now 3.0 RC1) (https://github.com/twitter/bootstrap/) navigation style in a custom theme using the WordPress built in menu manager.
 
 ![Extras](http://edwardmcintyre.com/pub/github/navwalker-extras-two.jpg)
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Simply add a Link menu item with a **URL** of `#` and a **Link Text** of `divide
 
 ![Divider Example](http://edwardmcintyre.com/pub/github/navwalker-divider.jpg)
 
+You can also add a vertical divider by adding a Link menu item with a **URL** of `#` and a **Link Text** of `divider-vertical`
+
 ######Navigation Headers
 Adding a navigation header is very similar, add a new link with a **URL** of `#` and a **Link Text** of `nav-header` (it matches the Bootstrap CSS class so it's easy to remember). When the item is added use the **Title Attribute** field to set your header text and the class will do the rest.
 
@@ -80,6 +82,9 @@ Adding a navigation header is very similar, add a new link with a **URL** of `#`
 
 Changelog
 ------------
+**1.4.3:**
++ Added support for vertical dividers (Thanks to @pattonwebz for the suggestion)
+
 **1.4.2:**
 + Removed redundant code from display_element by using function from parent class (Thanks to @sebakerckhof for the suggestion)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ To change your menu style add Bootstrap nav class names to the `menu_class` decl
 	);
 ?>
 ```
+
+Boostrap 3 Navbar uses `nav navbar-nav`.
+
+```php
+<?php 
+	wp_nav_menu( array(
+		'menu'		 => 'top_menu',
+		'depth'		 => 1,
+		'container'	 => false,
+		'menu_class' => 'nav navbar-nav',
+		'fallback_cb' => 'wp_page_menu',
+		//Process nav menu using our custom nav walker
+		'walker' => new wp_bootstrap_navwalker())
+	);
+?>
+```
+
 Review options in the Bootstrap docs for more information on nav classes
 http://twitter.github.com/bootstrap/components.html#navs
 
@@ -67,6 +84,7 @@ This script included the ability to add Bootstrap dividers and Nav Headers to yo
 
 ######Icons
 To add an Icon to your link simple place the full Glyphicon class name in the links **Title Attribute** field and the class will do the rest.
+* glyphicons needs to be incuded seporately now
 
 ######Dividers
 Simply add a Link menu item with a **URL** of `#` and a **Link Text** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
@@ -76,7 +94,9 @@ Simply add a Link menu item with a **URL** of `#` and a **Link Text** of `divide
 You can also add a vertical divider by adding a Link menu item with a **URL** of `#` and a **Link Text** of `divider-vertical`
 
 ######Navigation Headers
-Adding a navigation header is very similar, add a new link with a **URL** of `#` and a **Link Text** of `nav-header` (it matches the Bootstrap CSS class so it's easy to remember). When the item is added use the **Title Attribute** field to set your header text and the class will do the rest.
+Adding a navigation header is very similar, add a new link with a **URL** of `#` and a **Link Text** of `nav-header` (it matches the Bootstrap CSS class so it's easy to remember). When the item is added use the **Title Attribute** field to set your header text and the class will do the rest. Boostrap 3 uses a new class name `dropdown-header`. 
+
+Bootstrap 3 uses a new classname `dropdown-headers` for the headers. Currently you can use either or but backwards compatibility will be removed once Bootstrap 3 officially launches.
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-header.jpg)
 

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -53,9 +53,12 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 		} else if (strcasecmp($item->title, 'divider-vertical') == 0) {
 			// Item is a Vertical Divider
 			$output .= $indent . '<li class="divider-vertical">';
-		} else if (strcasecmp($item->title, 'nav-header') == 0) {
+		} else if (strcasecmp($item->title, 'nav-header') == 0) // this is contingency for backward compatibility - TOBEREMOVED {
 			// Item is a Header
-			$output .= $indent . '<li class="nav-header">' . esc_attr( $item->attr_title );
+			$output .= $indent . '<li class="dropdown-header">' . esc_attr( $item->attr_title );
+		} else if (strcasecmp($item->title, 'dropdown-header') == 0) // new dropdown header markup in BS3 {
+			// Item is a Header
+			$output .= $indent . '<li class="dropdown-header">' . esc_attr( $item->attr_title );
 		} else {
 
 			$class_names = $value = '';

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -4,7 +4,7 @@
  * Class Name: wp_bootstrap_navwalker
  * GitHub URI: https://github.com/twittem/wp-bootstrap-navwalker
  * Description: A custom WordPress nav walker class to implement the Twitter Bootstrap 2.3.2 navigation style in a custom theme using the WordPress built in menu manager.
- * Version: 1.4.2
+ * Version: 1.4.3
  * Author: Edward McIntyre - @twittem
  * License: GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
@@ -50,6 +50,9 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 		if (strcasecmp($item->title, 'divider') == 0) {
 			// Item is a Divider
 			$output .= $indent . '<li class="divider">';
+		} else if (strcasecmp($item->title, 'divider-vertical') == 0) {
+			// Item is a Vertical Divider
+			$output .= $indent . '<li class="divider-vertical">';
 		} else if (strcasecmp($item->title, 'nav-header') == 0) {
 			// Item is a Header
 			$output .= $indent . '<li class="nav-header">' . esc_attr( $item->attr_title );

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -53,10 +53,10 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 		} else if (strcasecmp($item->title, 'divider-vertical') == 0) {
 			// Item is a Vertical Divider
 			$output .= $indent . '<li class="divider-vertical">';
-		} else if (strcasecmp($item->title, 'nav-header') == 0) // this is contingency for backward compatibility - TOBEREMOVED {
+		} else if (strcasecmp($item->title, 'nav-header') == 0) /* this is contingency for backward compatibility - TOBEREMOVED  */ {
 			// Item is a Header
 			$output .= $indent . '<li class="dropdown-header">' . esc_attr( $item->attr_title );
-		} else if (strcasecmp($item->title, 'dropdown-header') == 0) // new dropdown header markup in BS3 {
+		} else if (strcasecmp($item->title, 'dropdown-header') == 0) /* new dropdown header markup in BS3  */ {
 			// Item is a Header
 			$output .= $indent . '<li class="dropdown-header">' . esc_attr( $item->attr_title );
 		} else {


### PR DESCRIPTION
Updated the "nav-header" class to "dropdown-header" to move inline with Bootstrap 3 RC1 classes.

Retained backwards compatibility for anyone who has "nav-header" in their existing menus which will output as the new class name. Backwards compatibility to be remove upon official launch of Bootstrap 3
