### PR TITLE
* Adds aria-haspopup accessibility property to dropdowns

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -85,6 +85,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 				$atts['href']   		= '#';
 				$atts['data-toggle']	= 'dropdown';
 				$atts['class']			= 'dropdown-toggle';
+				$atts['aria-haspopup']	= 'true';
 			} else {
 				$atts['href'] = ! empty( $item->url ) ? $item->url : '';
 			}


### PR DESCRIPTION
Just a small accessibility addition. The aria-haspopup property is added to the a element if the menu item has a sub-menu.

http://www.w3.org/TR/wai-aria/states_and_properties#aria-haspopup
