### PR TITLE
Icon font input proposal for WP-Bootstrap-Navwalker. 

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -108,9 +108,11 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			 * Since the the menu item is NOT a Divider or Header we check the see
 			 * if there is a value in the attr_title property. If the attr_title
 			 * property is NOT null we apply it as the class name for the glyphicon.
+			 *
+			 *  ---Updated to support icon fonts input feature in the backend
 			 */
-			if ( ! empty( $item->attr_title ) )
-				$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
+			if ( ! empty( $item->icon ) )
+				$item_output .= '<a'. $attributes .'>'. $item->icon . '&nbsp;';
 			else
 				$item_output .= '<a'. $attributes .'>';
 

--- a/wp_bstrp_nav_menu.php
+++ b/wp_bstrp_nav_menu.php
@@ -1,0 +1,273 @@
+<?php
+/**
+   * Icon font input proposal for WP-Bootstrap-Navwalker.
+   * Add this file in theme directory and 'include_once( 'wp_bstrp_nav_menu.php' );'
+   * before wp-bootstrap-navwalker line in 'functions.php'. 
+   * An icon font field will appear in the Menu Item settings page.
+   * TODO input validation/sanitization, code enhancements
+*/
+/**
+	 * Add custom fields to $item nav object
+	 * in order to be used in custom Walker
+	 *
+	 * @access      public
+	 * @since       1.0 
+	 * @return      void
+	*/
+	function wp_bstrp_icon_field( $menu_item ) {
+		$menu_item->icon = empty( $menu_item->icon ) ? get_post_meta( $menu_item->ID, '_menu_item_icon', true ) : $menu_item->icon;
+	    
+	    return $menu_item;
+	    
+	}
+add_filter( 'wp_setup_nav_menu_item', 'wp_bstrp_icon_field' );	
+	/**
+	 * Save menu custom fields
+	 *
+	 * @access      public
+	 * @since       1.0 
+	 * @return      void
+	*/
+	function wp_bstrp_custom_field_update( $menu_id, $menu_item_db_id, $args ) {
+	
+	    // Check if element is properly sent
+	    if ( is_array( $_REQUEST['menu-item-icon']) ) {
+	        $icon_value = $_REQUEST['menu-item-icon'][$menu_item_db_id];
+	        update_post_meta( $menu_item_db_id, '_menu_item_icon', $icon_value );
+	    }
+	    
+	}
+	// save menu custom fields
+		add_action( 'wp_update_nav_menu_item', 'wp_bstrp_custom_field_update', 10, 3 );
+	/**
+	 * Define new Walker edit
+	 *
+	 * @access      public
+	 * @since       1.0 
+	 * @return      void
+	*/
+	function wp_bstrp_edit_nav_menu($walker,$menu_id) {
+	
+	    return 'Walker_Nav_Menu_Edit_Custom';
+	    
+	}
+add_filter( 'wp_edit_nav_menu_walker', 'wp_bstrp_edit_nav_menu', 10, 2 );
+
+/**
+ *  /!\ This is a copy of Walker_Nav_Menu_Edit class in core
+ * 
+ * Create HTML list of nav menu input items.
+ *
+ * @package WordPress
+ * @since 3.0.0
+ * @uses Walker_Nav_Menu
+ */
+class Walker_Nav_Menu_Edit_Custom extends Walker_Nav_Menu  {
+	/**
+	 * @see Walker_Nav_Menu::start_lvl()
+	 * @since 3.0.0
+	 *
+	 * @param string $output Passed by reference.
+	 */
+	function start_lvl(&$output) {	
+	}
+	
+	/**
+	 * @see Walker_Nav_Menu::end_lvl()
+	 * @since 3.0.0
+	 *
+	 * @param string $output Passed by reference.
+	 */
+	function end_lvl(&$output) {
+	}
+	
+	/**
+	 * @see Walker::start_el()
+	 * @since 3.0.0
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param object $item Menu item data object.
+	 * @param int $depth Depth of menu item. Used for padding.
+	 * @param object $args
+	 */
+	function start_el(&$output, $item, $depth, $args) {
+	    global $_wp_nav_menu_max_depth;
+	   
+	    $_wp_nav_menu_max_depth = $depth > $_wp_nav_menu_max_depth ? $depth : $_wp_nav_menu_max_depth;
+	
+	    $indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
+	
+	    ob_start();
+	    $item_id = esc_attr( $item->ID );
+	    $removed_args = array(
+	        'action',
+	        'customlink-tab',
+	        'edit-menu-item',
+	        'menu-item',
+	        'page-tab',
+	        '_wpnonce',
+	    );
+	
+	    $original_title = '';
+	    if ( 'taxonomy' == $item->type ) {
+	        $original_title = get_term_field( 'name', $item->object_id, $item->object, 'raw' );
+	        if ( is_wp_error( $original_title ) )
+	            $original_title = false;
+	    } elseif ( 'post_type' == $item->type ) {
+	        $original_object = get_post( $item->object_id );
+	        $original_title = $original_object->post_title;
+	    }
+	
+	    $classes = array(
+	        'menu-item menu-item-depth-' . $depth,
+	        'menu-item-' . esc_attr( $item->object ),
+	        'menu-item-edit-' . ( ( isset( $_GET['edit-menu-item'] ) && $item_id == $_GET['edit-menu-item'] ) ? 'active' : 'inactive'),
+	    );
+	
+	    $title = $item->title;
+	
+	    if ( ! empty( $item->_invalid ) ) {
+	        $classes[] = 'menu-item-invalid';
+	        /* translators: %s: title of menu item which is invalid */
+	        $title = sprintf( __( '%s (Invalid)' ), $item->title );
+	    } elseif ( isset( $item->post_status ) && 'draft' == $item->post_status ) {
+	        $classes[] = 'pending';
+	        /* translators: %s: title of menu item in draft status */
+	        $title = sprintf( __('%s (Pending)'), $item->title );
+	    }
+	
+	    $title = empty( $item->label ) ? $title : $item->label;
+	
+	    ?>
+	    <li id="menu-item-<?php echo $item_id; ?>" class="<?php echo implode(' ', $classes ); ?>">
+	        <dl class="menu-item-bar">
+	            <dt class="menu-item-handle">
+	                <span class="item-title"><?php echo esc_html( $title ); ?></span>
+	                <span class="item-controls">
+	                    <span class="item-type"><?php echo esc_html( $item->type_label ); ?></span>
+	                    <span class="item-order hide-if-js">
+	                        <a href="<?php
+	                            echo wp_nonce_url(
+	                                add_query_arg(
+	                                    array(
+	                                        'action' => 'move-up-menu-item',
+	                                        'menu-item' => $item_id,
+	                                    ),
+	                                    remove_query_arg($removed_args, admin_url( 'nav-menus.php' ) )
+	                                ),
+	                                'move-menu_item'
+	                            );
+	                        ?>" class="item-move-up"><abbr title="<?php esc_attr_e('Move up'); ?>">&#8593;</abbr></a>
+	                        |
+	                        <a href="<?php
+	                            echo wp_nonce_url(
+	                                add_query_arg(
+	                                    array(
+	                                        'action' => 'move-down-menu-item',
+	                                        'menu-item' => $item_id,
+	                                    ),
+	                                    remove_query_arg($removed_args, admin_url( 'nav-menus.php' ) )
+	                                ),
+	                                'move-menu_item'
+	                            );
+	                        ?>" class="item-move-down"><abbr title="<?php esc_attr_e('Move down'); ?>">&#8595;</abbr></a>
+	                    </span>
+	                    <a class="item-edit" id="edit-<?php echo $item_id; ?>" title="<?php esc_attr_e('Edit Menu Item'); ?>" href="<?php
+	                        echo ( isset( $_GET['edit-menu-item'] ) && $item_id == $_GET['edit-menu-item'] ) ? admin_url( 'nav-menus.php' ) : add_query_arg( 'edit-menu-item', $item_id, remove_query_arg( $removed_args, admin_url( 'nav-menus.php#menu-item-settings-' . $item_id ) ) );
+	                    ?>"><?php _e( 'Edit Menu Item' ); ?></a>
+	                </span>
+	            </dt>
+	        </dl>
+	
+	        <div class="menu-item-settings" id="menu-item-settings-<?php echo $item_id; ?>">
+	            <?php if( 'custom' == $item->type ) : ?>
+	                <p class="field-url description description-wide">
+	                    <label for="edit-menu-item-url-<?php echo $item_id; ?>">
+	                        <?php _e( 'URL' ); ?><br />
+	                        <input type="text" id="edit-menu-item-url-<?php echo $item_id; ?>" class="widefat code edit-menu-item-url" name="menu-item-url[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->url ); ?>" />
+	                    </label>
+	                </p>
+	            <?php endif; ?>
+	            <p class="description description-thin">
+	                <label for="edit-menu-item-title-<?php echo $item_id; ?>">
+	                    <?php _e( 'Navigation Label' ); ?><br />
+	                    <input type="text" id="edit-menu-item-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-title" name="menu-item-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->title ); ?>" />
+	                </label>
+	            </p>
+	            <p class="description description-thin">
+	                <label for="edit-menu-item-attr-title-<?php echo $item_id; ?>">
+	                    <?php _e( 'Title Attribute' ); ?><br />
+	                    <input type="text" id="edit-menu-item-attr-title-<?php echo $item_id; ?>" class="widefat edit-menu-item-attr-title" name="menu-item-attr-title[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->post_excerpt ); ?>" />
+	                </label>
+	            </p>
+	            <p class="field-link-target description">
+	                <label for="edit-menu-item-target-<?php echo $item_id; ?>">
+	                    <input type="checkbox" id="edit-menu-item-target-<?php echo $item_id; ?>" value="_blank" name="menu-item-target[<?php echo $item_id; ?>]"<?php checked( $item->target, '_blank' ); ?> />
+	                    <?php _e( 'Open link in a new window/tab' ); ?>
+	                </label>
+	            </p>
+	            <p class="field-css-classes description description-thin">
+	                <label for="edit-menu-item-classes-<?php echo $item_id; ?>">
+	                    <?php _e( 'CSS Classes (optional)' ); ?><br />
+	                    <input type="text" id="edit-menu-item-classes-<?php echo $item_id; ?>" class="widefat code edit-menu-item-classes" name="menu-item-classes[<?php echo $item_id; ?>]" value="<?php echo esc_attr( implode(' ', $item->classes ) ); ?>" />
+	                </label>
+	            </p>
+	            <p class="field-xfn description description-thin">
+	                <label for="edit-menu-item-xfn-<?php echo $item_id; ?>">
+	                    <?php _e( 'Link Relationship (XFN)' ); ?><br />
+	                    <input type="text" id="edit-menu-item-xfn-<?php echo $item_id; ?>" class="widefat code edit-menu-item-xfn" name="menu-item-xfn[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->xfn ); ?>" />
+	                </label>
+	            </p>
+	            <p class="field-description description description-wide">
+	                <label for="edit-menu-item-description-<?php echo $item_id; ?>">
+	                    <?php _e( 'Description' ); ?><br />
+	                    <textarea id="edit-menu-item-description-<?php echo $item_id; ?>" class="widefat edit-menu-item-description" rows="3" cols="20" name="menu-item-description[<?php echo $item_id; ?>]"><?php echo esc_html( $item->description ); // textarea_escaped ?></textarea>
+	                    <span class="description"><?php _e('The description will be displayed in the menu if the current theme supports it.'); ?></span>
+	                </label>
+	            </p>        
+	            <?php
+	            /* New fields insertion starts here */
+	            ?>      
+	            <p class="field-custom description description-wide">
+	                <label for="edit-menu-item-icon-<?php echo $item_id; ?>">
+	                    <?php _e( 'Icon Font tag' ); ?><br />
+	                    <input type="text" id="edit-menu-item-icon-<?php echo $item_id; ?>" class="widefat code edit-menu-item-custom" name="menu-item-icon[<?php echo $item_id; ?>]" value="<?php echo esc_html( $item->icon ); ?>" />
+	                </label>
+	            </p>
+	            <?php
+	            /* New fields insertion ends here */
+	            ?>
+	            <div class="menu-item-actions description-wide submitbox">
+	                <?php if( 'custom' != $item->type && $original_title !== false ) : ?>
+	                    <p class="link-to-original">
+	                        <?php printf( __('Original: %s'), '<a href="' . esc_attr( $item->url ) . '">' . esc_html( $original_title ) . '</a>' ); ?>
+	                    </p>
+	                <?php endif; ?>
+	                <a class="item-delete submitdelete deletion" id="delete-<?php echo $item_id; ?>" href="<?php
+	                echo wp_nonce_url(
+	                    add_query_arg(
+	                        array(
+	                            'action' => 'delete-menu-item',
+	                            'menu-item' => $item_id,
+	                        ),
+	                        remove_query_arg($removed_args, admin_url( 'nav-menus.php' ) )
+	                    ),
+	                    'delete-menu_item_' . $item_id
+	                ); ?>"><?php _e('Remove'); ?></a> <span class="meta-sep"> | </span> <a class="item-cancel submitcancel" id="cancel-<?php echo $item_id; ?>" href="<?php echo esc_url( add_query_arg( array('edit-menu-item' => $item_id, 'cancel' => time()), remove_query_arg( $removed_args, admin_url( 'nav-menus.php' ) ) ) );
+	                    ?>#menu-item-settings-<?php echo $item_id; ?>"><?php _e('Cancel'); ?></a>
+	            </div>
+	
+	            <input class="menu-item-data-db-id" type="hidden" name="menu-item-db-id[<?php echo $item_id; ?>]" value="<?php echo $item_id; ?>" />
+	            <input class="menu-item-data-object-id" type="hidden" name="menu-item-object-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->object_id ); ?>" />
+	            <input class="menu-item-data-object" type="hidden" name="menu-item-object[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->object ); ?>" />
+	            <input class="menu-item-data-parent-id" type="hidden" name="menu-item-parent-id[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->menu_item_parent ); ?>" />
+	            <input class="menu-item-data-position" type="hidden" name="menu-item-position[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->menu_order ); ?>" />
+	            <input class="menu-item-data-type" type="hidden" name="menu-item-type[<?php echo $item_id; ?>]" value="<?php echo esc_attr( $item->type ); ?>" />
+	        </div><!-- .menu-item-settings-->
+	        <ul class="menu-item-transport"></ul>
+	    <?php
+	    
+	    $output .= ob_get_clean();
+
+	    }
+}

--- a/wp_bstrp_nav_menu.php
+++ b/wp_bstrp_nav_menu.php
@@ -23,7 +23,9 @@
 add_filter( 'wp_setup_nav_menu_item', 'wp_bstrp_icon_field' );	
 	/**
 	 * Save menu custom fields
-	 *
+	 * Added wp_kses validation, leaves database clean when empty
+	 * Allowed icon font tags: <span></span>, <i></i> and 'class' attribute
+	 * 
 	 * @access      public
 	 * @since       1.0 
 	 * @return      void
@@ -32,8 +34,20 @@ add_filter( 'wp_setup_nav_menu_item', 'wp_bstrp_icon_field' );
 	
 	    // Check if element is properly sent
 	    if ( is_array( $_REQUEST['menu-item-icon']) ) {
-	        $icon_value = $_REQUEST['menu-item-icon'][$menu_item_db_id];
-	        update_post_meta( $menu_item_db_id, '_menu_item_icon', $icon_value );
+	        $allowed_tags = array(
+				'span' => array( 'class' => array()),
+				'i' => array( 'class' => array())
+				);
+			$icon_value_unfiltered = $_REQUEST['menu-item-icon'][$menu_item_db_id];
+			$icon_value = wp_kses($icon_value_unfiltered, $allowed_tags);
+			
+			if ( !empty($icon_value) ) {
+	        		update_post_meta( $menu_item_db_id, '_menu_item_icon', $icon_value );
+			
+			} else {
+			
+			delete_post_meta( $menu_item_db_id, '_menu_item_icon');
+			}
 	    }
 	    
 	}


### PR DESCRIPTION
First draft for the input field in the backend, minor change in the wp-bootstrap-navwalker file.
Uses an extra file to put in theme directory, add 'include_once( 'wp_bstrp_nav_menu.php' );' 
before wp-bootstrap-navwalker line in 'functions.php'. 
An icon font field will appear in the Menu Item settings page. 
TODO input validation/sanitization, code enhancements (eventually merge this extra file?)  

screenshots:
![github 1 - menus cristovao verstraeten wordpress - wptrunk_dev_wordpress_wp-admin_nav-menus_php](https://cloud.githubusercontent.com/assets/5374958/2600664/e0a9b8ec-bb02-11e3-9b04-fe3fb5912226.png)
![github 2 - menus cristovao verstraeten wordpress - wptrunk_dev_wordpress_wp-admin_nav-menus_php](https://cloud.githubusercontent.com/assets/5374958/2600666/f11dad82-bb02-11e3-80aa-8a6b519aaa12.png)
![github 3 - cristovao verstraeten i tailored wordpress development services - wptrunk_dev](https://cloud.githubusercontent.com/assets/5374958/2600678/2261241e-bb03-11e3-9a20-c306941b9e25.png)
