### PR TITLE
Coding standards and code improvements

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -4,13 +4,13 @@
  * Class Name: wp_bootstrap_navwalker
  * GitHub URI: https://github.com/twittem/wp-bootstrap-navwalker
  * Description: A custom WordPress nav walker class to implement the Bootstrap 3 navigation style in a custom theme using the WordPress built in menu manager.
- * Version: 2.0.4
+ * Version: 2.1.4
  * Author: Edward McIntyre - @twittem
  * License: GPL-2.0+
  * License URI: http://www.gnu.org/licenses/gpl-2.0.txt
  */
 
-class wp_bootstrap_navwalker extends Walker_Nav_Menu {
+class Wp_Bootstrap_Nav_Walker extends Walker_Nav_Menu {
 
 	/**
 	 * @see Walker::start_lvl()
@@ -28,10 +28,10 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @see Walker::start_el()
 	 * @since 3.0.0
 	 *
-	 * @param string $output Passed by reference. Used to append additional content.
-	 * @param object $item Menu item data object.
-	 * @param int $depth Depth of menu item. Used for padding.
-	 * @param int $current_page Menu item ID.
+	 * @param string $output     Passed by reference. Used to append additional content.
+	 * @param object $item       Menu item data object.
+	 * @param int $depth         Depth of menu item. Used for padding.
+	 * @param int $current_page  Menu item ID.
 	 * @param object $args
 	 */
 	public function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
@@ -62,18 +62,20 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 
 			$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
 
-			if ( $args->has_children )
+			if ( $args->has_children ) {
 				$class_names .= ' dropdown';
+			}
 
-			if ( in_array( 'current-menu-item', $classes ) )
+			if ( in_array( 'current-menu-item', $classes ) ) {
 				$class_names .= ' active';
+			}
 
-			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+			$class_names = $class_names ? sprintf( ' class="%s"', esc_attr( $class_names ) ) : '';
 
 			$id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args );
-			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+			$id = $id ? sprintf( ' id="%s"', esc_attr( $id ) ) : '';
 
-			$output .= $indent . '<li' . $id . $value . $class_names .'>';
+			$output .= $indent . '<li' . $id . $value . $class_names . '>';
 
 			$atts = array();
 			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
@@ -96,7 +98,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			foreach ( $atts as $attr => $value ) {
 				if ( ! empty( $value ) ) {
 					$value = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
-					$attributes .= ' ' . $attr . '="' . $value . '"';
+					$attributes .= " {$attr}=\"{$value}\"";
 				}
 			}
 
@@ -109,10 +111,11 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			 * if there is a value in the attr_title property. If the attr_title
 			 * property is NOT null we apply it as the class name for the glyphicon.
 			 */
-			if ( ! empty( $item->attr_title ) )
-				$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
-			else
-				$item_output .= '<a'. $attributes .'>';
+			if ( ! empty( $item->attr_title ) ) {
+				$item_output .= sprintf( '<a%s><span class="glyphicon %s"></span>&nbsp;', $attributes, esc_attr( $item->attr_title ) );
+			} else {
+				$item_output .= "<a{$attributes}>";
+			}
 
 			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
 			$item_output .= ( $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';
@@ -134,23 +137,26 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @see Walker::start_el()
 	 * @since 2.5.0
 	 *
-	 * @param object $element Data object
-	 * @param array $children_elements List of elements to continue traversing.
-	 * @param int $max_depth Max depth to traverse.
-	 * @param int $depth Depth of current element.
+	 * @param object $element           Data object
+	 * @param array $children_elements  List of elements to continue traversing.
+	 * @param int $max_depth            Max depth to traverse.
+	 * @param int $depth                Depth of current element.
 	 * @param array $args
-	 * @param string $output Passed by reference. Used to append additional content.
-	 * @return null Null on failure with no changes to parameters.
+	 * @param string $output            Passed by reference. Used to append additional content.
+	 * @return null                     Null on failure with no changes to parameters.
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-        if ( ! $element )
+
+        if ( ! $element ) {
             return;
+        }
 
         $id_field = $this->db_fields['id'];
 
-        // Display this element.
-        if ( is_object( $args[0] ) )
+        // Display this element
+        if ( is_object( $args[0] ) ) {
            $args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
+        }
 
         parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
     }
@@ -167,40 +173,30 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 *
 	 */
 	public static function fallback( $args ) {
+
 		if ( current_user_can( 'manage_options' ) ) {
 
 			extract( $args );
 
-			$fb_output = null;
+			$output = sprintf( 
+				'<ul%s%s><li><a href="%s">Add a menu</a></li></ul>', 
+				( $menu_id )    ? " id=\"{$menu_id}\"" : '',
+				( $menu_class ) ? " class=\"{$menu_class}\"" : '',
+				admin_url( 'nav-menus.php' )
+			);
 
 			if ( $container ) {
-				$fb_output = '<' . $container;
 
-				if ( $container_id )
-					$fb_output .= ' id="' . $container_id . '"';
-
-				if ( $container_class )
-					$fb_output .= ' class="' . $container_class . '"';
-
-				$fb_output .= '>';
+				$output = sprintf( 
+					'<%1$s%2$s%3$s>%4$s</%1$s>', 
+					$container,
+					( $container_id )    ? " id=\"{$container_id}\"" : '',
+					( $container_class ) ? " class=\"{$container_class}\"" : '',
+					$output
+				);
 			}
 
-			$fb_output .= '<ul';
-
-			if ( $menu_id )
-				$fb_output .= ' id="' . $menu_id . '"';
-
-			if ( $menu_class )
-				$fb_output .= ' class="' . $menu_class . '"';
-
-			$fb_output .= '>';
-			$fb_output .= '<li><a href="' . admin_url( 'nav-menus.php' ) . '">Add a menu</a></li>';
-			$fb_output .= '</ul>';
-
-			if ( $container )
-				$fb_output .= '</' . $container . '>';
-
-			echo $fb_output;
+			echo $output;
 		}
 	}
 }


### PR DESCRIPTION
- WP coding standards say class names should be capitalized - applied here.
- Recent addition to the WP coding standards say every is statement should be have curly brackets - applied here.
- Added some missing spaces and aligned the doc descriptions
- I dislike hacking strings into little `'<'`, `'"'` pieces so I added a bit `sprintf` and `{$curly}` to make the code cleaner.
- **I did not test the fallback function** since I actually don't know how to trigger it correctly. `Missing argument 1 ...` it tells me. Please tell me how to trigger this.
- I escaped double quotes instead of single quotes because there might be some rare cases where some bad JS regexes fail on menu manipulation when single quotes would be used for menu attris or things like that. You may replace them with single quotes of you feel like it to make it even more cleaner.
