### PR TITLE
Added dropdown class, support for deep menus (>1 level), and composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
-wp-bootstrap-navwalker
-======================
+# wp-bootstrap-navwalker
 
 **A custom WordPress nav walker class to fully implement the Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.**
 
 ![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
 
-Bootstrap 2.x vs Bootstrap 3.0
-------------
+## Bootstrap 2.x vs Bootstrap 3.0
+
 There are many changes Bootstrap 2.x & Bootstrap 3.0 that affect both how the nav walker class is used and what the walker supports. For CSS changes I recommend reading the Migrating from 2.x to 3.0 in the official Bootstrap docs http://getbootstrap.com/getting-started/#migration
 
 The most noticeable functionality change in Bootstrap 3.0.0+ is that it only supports a single dropdown level. This script is intended to implement the Bootstrap 3.0 menu structure without adding additional features, so additional dropdown levels will not be supported.
 
 If you would like to use **Bootstrap 2.x** you can find the legacy version of the walker class here https://github.com/twittem/wp-bootstrap-navwalker/tree/For-Bootstrap-2.3.2
 
-NOTE
-----
+## NOTE
+
 This is a utility class that is intended to format your WordPress theme menu with the correct syntax and classes to utilize the Bootstrap dropdown navigation, and does not include the required Bootstrap JS files. You will have to include them manually. 
 
-Installation
-------------
+## Installation
+
 Place **wp_bootstrap_navwalker.php** in your WordPress theme folder `/wp-content/your-theme/`
 
 Open your WordPress themes **functions.php** file  `/wp-content/your-theme/functions.php` and add the following code:
@@ -28,8 +27,8 @@ Open your WordPress themes **functions.php** file  `/wp-content/your-theme/funct
 require_once('wp_bootstrap_navwalker.php');
 ```
 
-Usage
-------------
+## Usage
+
 Update your `wp_nav_menu()` function in `header.php` to use the new walker by adding a "walker" item to the wp_nav_menu array.
 
 ```php
@@ -100,7 +99,7 @@ To change your menu style add Bootstrap nav class names to the `menu_class` decl
 Review options in the Bootstrap docs for more information on nav classes
 http://getbootstrap.com/components/#nav
 
-## Deep menus
+### Deep menus
 
 Bootstrap does not display more than one level of menus, so if your menu is deeper,
 it will be flattened: all items at depth > 0 will be listed at same level.
@@ -111,6 +110,8 @@ depth-based class, and define proper indentation in your css files:
 ...
                 'depth_class_prefix' => 'd',
 ...
+```
+
 ```css
 .d1 {
     margin-left: 15px;
@@ -121,44 +122,44 @@ depth-based class, and define proper indentation in your css files:
 
 ```
 
-Displaying the Menu 
--------------------
+## Displaying the Menu 
+
 To display the menu you must associate your menu with your theme location. You can do this by selecting your theme location in the *Theme Locations* list wile editing a menu in the WordPress menu manager.
 
-Extras
-------------
+## Extras
+
 
 ![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
 
 This script included the ability to add dividers, dropdown headers, glyphicons,
  and disable links, all through the WordPress menu UI.
 
-## Dividers
+### Dividers
 
 Simply add a Link menu item with a **URL** of `#` and a **Link Text** or **Title Attribute** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
 
 ![Divider Example](http://edwardmcintyre.com/pub/github/navwalker-divider.jpg)
 
-## Glyphicons
+### Glyphicons
 
 To add an Icon to your link simple place the Glyphicon class name in the links **Title Attribute** field and the class will do the rest. IE `glyphicon-bullhorn`
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-glyphicons.jpg)
 
-## Dropdown Headers
+### Dropdown Headers
 
 Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-header.jpg)
 
-## Disabled Links
+### Disabled Links
 
 To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest. 
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-disabled.jpg)
 
-Changelog
-------------
+## Changelog
+
 **2.0.4**
 + Updated fallback function to accept args array from wp_nav_menu
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Update your `wp_nav_menu()` function in `header.php` to use the new walker by ad
                 'depth'             => 2,
                 'container'         => 'div',
                 'container_class'   => 'collapse navbar-collapse',
-		'container_id'      => 'bs-example-navbar-collapse-1',
+                'container_id'      => 'bs-example-navbar-collapse-1',
                 'menu_class'        => 'nav navbar-nav',
+                'dropdown_class'    => 'dropdown-menu',
+                'depth_class_prefix' => 'd',
                 'fallback_cb'       => 'wp_bootstrap_navwalker::fallback',
                 'walker'            => new wp_bootstrap_navwalker())
             );
@@ -83,7 +85,7 @@ Typically the menu is wrapped with additional markup, here is an example of a ` 
                 'depth'             => 2,
                 'container'         => 'div',
                 'container_class'   => 'collapse navbar-collapse',
-		'container_id'      => 'bs-example-navbar-collapse-1',
+                'container_id'      => 'bs-example-navbar-collapse-1',
                 'menu_class'        => 'nav navbar-nav',
                 'fallback_cb'       => 'wp_bootstrap_navwalker::fallback',
                 'walker'            => new wp_bootstrap_navwalker())
@@ -98,6 +100,27 @@ To change your menu style add Bootstrap nav class names to the `menu_class` decl
 Review options in the Bootstrap docs for more information on nav classes
 http://getbootstrap.com/components/#nav
 
+## Deep menus
+
+Bootstrap does not display more than one level of menus, so if your menu is deeper,
+it will be flattened: all items at depth > 0 will be listed at same level.
+You can set the option `depth_class_prefix` so that all items get assigned a
+depth-based class, and define proper indentation in your css files:
+
+```php
+...
+                'depth_class_prefix' => 'd',
+...
+```css
+.d1 {
+    margin-left: 15px;
+}
+.d2 {
+    margin-left: 30px;
+}
+
+```
+
 Displaying the Menu 
 -------------------
 To display the menu you must associate your menu with your theme location. You can do this by selecting your theme location in the *Theme Locations* list wile editing a menu in the WordPress menu manager.
@@ -107,28 +130,29 @@ Extras
 
 ![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
 
-This script included the ability to add Bootstrap dividers, dropdown headers, glyphicons and disables links to your menus through the WordPress menu UI. 
+This script included the ability to add dividers, dropdown headers, glyphicons,
+ and disable links, all through the WordPress menu UI.
 
-Dividers
-------------
+## Dividers
+
 Simply add a Link menu item with a **URL** of `#` and a **Link Text** or **Title Attribute** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
 
 ![Divider Example](http://edwardmcintyre.com/pub/github/navwalker-divider.jpg)
 
-Glyphicons
-------------
+## Glyphicons
+
 To add an Icon to your link simple place the Glyphicon class name in the links **Title Attribute** field and the class will do the rest. IE `glyphicon-bullhorn`
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-glyphicons.jpg)
 
-Dropdown Headers
-------------
+## Dropdown Headers
+
 Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-header.jpg)
 
-Disabled Links
-------------
+## Disabled Links
+
 To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest. 
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-disabled.jpg)

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "twittem/wp-bootstrap-navwalker",
+  "description": "A custom WordPress nav walker class to fully implement the Twitter Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.",
+  "license": "GPL-2.0+",
+  "homepage": "http://twittem.github.io/wp-bootstrap-navwalker/",
+  "authors": [
+    {
+      "name": "Edward McIntyre",
+      "email": "edward@edwardmcintyre.com"
+    }
+  ],
+  "require": {
+  },
+  "autoload": {
+    "files": ["wp_bootstrap_navwalker.php"]
+  }
+}

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -20,8 +20,20 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @param int $depth Depth of page. Used for padding.
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
-		$indent = str_repeat( "\t", $depth );
-		$output .= "\n$indent<ul role=\"menu\" class=\" dropdown-menu\">\n";
+		// Bootstrap doesn't have multi-level menus,
+		// so we flatten all depths >=1
+		if($depth == 0) {
+			$indent = str_repeat( "\t", $depth );
+			$class = isset($args->dropdown_class) ? $args->dropdown_class : 'dropdown-menu';
+			$output .= "\n$indent<ul role=\"menu\" class=\" $class\">\n";
+		}
+	}
+
+	public function end_lvl( &$output, $depth = 0, $args = array() ) {
+		if($depth == 0) {
+			$indent = str_repeat("\t", $depth);
+			$output .= "$indent</ul>\n";
+		}
 	}
 
 	/**
@@ -67,6 +79,10 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 
 			if ( in_array( 'current-menu-item', $classes ) )
 				$class_names .= ' active';
+
+			if (isset($args->depth_class_prefix)) {
+				$class_names .= ' '.$args->depth_class_prefix.$depth;
+			}
 
 			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 


### PR DESCRIPTION
Hi,

1/ added an option to specify the dropdown-menu class (defaults to `dropdown-menu`). I needed it to put left-aligned dropdowns in a right-side menu bar

2/ added basic support for menus deeper than 1 level: walker lists all depth >1 at same level, you can use an option to add depth-specific classes and style them with indentations.

3/ [Composer](https://getcomposer.org/) is great to easily manage project dependencies, and include your library in other wordpress themes. So I added a file+tag to make your walker compatible with it (this is a beefed-up version of #128).

All options default properly to previous behavior, so no impact on existing installs.

Xavier
