### PR TITLE
reassigns classes array after applying filters - fixes #156

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -60,7 +60,8 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 			$classes[] = 'menu-item-' . $item->ID;
 
-			$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
+      $classes = apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args );
+			$class_names = join( ' ', $classes );
 
 			if ( $args->has_children )
 				$class_names .= ' dropdown';


### PR DESCRIPTION
Updates the `$classes` array so the `nav_menu_css_class` filter can manipulate the addition of the `.active` class and other behavior dependent on updated `$classes` array values - fixes #156 
