### PR TITLE
Correctly reference a menu item's custom title attribute

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -76,7 +76,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$output .= $indent . '<li' . $id . $value . $class_names .'>';
 
 			$atts = array();
-			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
+			$atts['title']  = ! empty( $item->attr_title )	? $item->attr_title	: '';
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
 			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
 


### PR DESCRIPTION
Currently the menu item's label is being set as the link's title attribute, which is incorrect. This fixes it.
