### PR TITLE
Bootstrap v4.0.0-alpha1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 wp-bootstrap-navwalker
 ======================
 
-**A custom WordPress nav walker class to fully implement the Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.**
+**A custom WordPress nav walker class to fully implement the Bootstrap 4.0+ navigation style in a custom theme using the WordPress built in menu manager.**
 
-![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
+Bootstrap 3.x vs Bootstrap 4.0
+------------
+There are many changes Bootstrap 3.x & Bootstrap 4.0 that affect both how the nav walker class is used and what the walker supports. For CSS changes I recommend reading the Migrating from 3.x to 4.0 in the official Bootstrap docs http://v4-alpha.getbootstrap.com/migration/
 
-Bootstrap 2.x vs Bootstrap 3.0
+The most noticeable functionality change in Bootstrap 3.0.0+ is that it only supports a single dropdown level. This script is intended to implement the Bootstrap 3.0 menu structure without adding additional features, so additional dropdown levels will not be supported.
+
+If you would like to use **Bootstrap 3.x** you can find the legacy version of the walker class here
+
+Bootstrap 2.x vs Bootstrap 3.x
 ------------
 There are many changes Bootstrap 2.x & Bootstrap 3.0 that affect both how the nav walker class is used and what the walker supports. For CSS changes I recommend reading the Migrating from 2.x to 3.0 in the official Bootstrap docs http://getbootstrap.com/getting-started/#migration
 

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -12,7 +12,7 @@
 
 class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 
-	/**
+		/**
 	 * @see Walker::start_lvl()
 	 * @since 3.0.0
 	 *
@@ -21,7 +21,23 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 */
 	public function start_lvl( &$output, $depth = 0, $args = array() ) {
 		$indent = str_repeat( "\t", $depth );
-		$output .= "\n$indent<ul role=\"menu\" class=\" dropdown-menu\">\n";
+		$output .= "\n$indent<div role=\"menu\" class=\" dropdown-menu\">\n";
+	}
+
+	/**
+	 * Ends the list of after the elements are added.
+	 *
+	 * @see Walker::end_lvl()
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of arguments. @see wp_nav_menu()
+	 */
+	public function end_lvl( &$output, $depth = 0, $args = array() ) {
+		$indent = str_repeat("\t", $depth);
+		$output .= "$indent</div>\n";
 	}
 
 	/**

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -55,7 +55,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 */
 	public function end_el( &$output, $item, $depth = 0, $args = array() ) {
 		if($depth === 1){
-			if(strcasecmp( $item->attr_title, 'divider' ) == 0 || strcasecmp( $item->title, 'divider') == 0)) {
+			if(strcasecmp( $item->attr_title, 'divider' ) == 0 || strcasecmp( $item->title, 'divider') == 0) {
 				$output .= '</div>';
 			}else if ($depth === 1 && (strcasecmp( $item->attr_title, 'header') == 0 && $depth === 1)) {
 				$output .= '</h6>';

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -25,6 +25,31 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	}
 
 	/**
+	 * Start the element output.
+	 *
+	 * @see Walker::start_el()
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param string $output Passed by reference. Used to append additional content.
+	 * @param object $item   Menu item data object.
+	 * @param int    $depth  Depth of menu item. Used for padding.
+	 * @param array  $args   An array of arguments. @see wp_nav_menu()
+	 * @param int    $id     Current item ID.
+	 */
+	public function end_el( &$output, $item, $depth = 0, $args = array() ) {
+		if($depth === 1){
+			if(strcasecmp( $item->attr_title, 'divider' ) == 0 || strcasecmp( $item->title, 'divider') == 0)) {
+				$output .= '</div>';
+			}else if ($depth === 1 && (strcasecmp( $item->attr_title, 'header') == 0 && $depth === 1)) {
+				$output .= '</h6>';
+			}
+		}else{
+			$output .= '</li>';
+		}
+	}
+
+	/**
 	 * @see Walker::start_el()
 	 * @since 3.0.0
 	 *
@@ -45,51 +70,53 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 		 * comparison that is not case sensitive. The strcasecmp() function returns
 		 * a 0 if the strings are equal.
 		 */
-		if ( strcasecmp( $item->attr_title, 'divider' ) == 0 && $depth === 1 ) {
-			$output .= $indent . '<li role="presentation" class="divider">';
-		} else if ( strcasecmp( $item->title, 'divider') == 0 && $depth === 1 ) {
-			$output .= $indent . '<li role="presentation" class="divider">';
-		} else if ( strcasecmp( $item->attr_title, 'dropdown-header') == 0 && $depth === 1 ) {
-			$output .= $indent . '<li role="presentation" class="dropdown-header">' . esc_attr( $item->title );
-		} else if ( strcasecmp($item->attr_title, 'disabled' ) == 0 ) {
-			$output .= $indent . '<li role="presentation" class="disabled"><a href="#">' . esc_attr( $item->title ) . '</a>';
-		} else {
 
+		//( strcasecmp($item->attr_title, 'disabled' ) == 0 ) 
+		
+		if($depth === 1 && (strcasecmp( $item->attr_title, 'divider' ) == 0 || strcasecmp( $item->title, 'divider') == 0)) {
+			$output .= $indent . '<div class="dropdown-divider">';
+		}else if ((strcasecmp( $item->attr_title, 'header') == 0 && $depth === 1) && $depth === 1){
+			$output .= $indent . '<h6 class="dropdown-header">' . esc_attr( $item->title );
+		}else{
 			$class_names = $value = '';
 
 			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
-			$classes[] = 'menu-item-' . $item->ID;
-
-			$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
-
-			if ( $args->has_children )
-				$class_names .= ' dropdown';
-
-			if ( in_array( 'current-menu-item', $classes ) )
-				$class_names .= ' active';
-
-			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
-
-			$id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args );
-			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
-
-			$output .= $indent . '<li' . $id . $value . $class_names .'>';
-
+			
 			$atts = array();
 			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
 			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
+			$atts['href'] = ! empty( $item->url ) ? $item->url : '';
 
-			// If item has_children add atts to a.
-			if ( $args->has_children && $depth === 0 ) {
-				$atts['href']   		= '#';
-				$atts['data-toggle']	= 'dropdown';
-				$atts['class']			= 'dropdown-toggle';
-				$atts['aria-haspopup']	= 'true';
-			} else {
-				$atts['href'] = ! empty( $item->url ) ? $item->url : '';
+			$id = apply_filters( 'nav_menu_item_id', 'menu-item-'. $item->ID, $item, $args );
+			
+			if ( in_array( 'current-menu-item', $classes ) )
+				$classes[] = ' active';
+
+			if($depth === 0){
+				$classes[] = 'nav-item';
+				$classes[] = 'nav-item-' . $item->ID;
+				$atts['class']			= 'nav-link';
+				if ( $args->has_children ){
+					$classes[] = ' dropdown';
+					$atts['href']   		= '#';
+					$atts['data-toggle']	= 'dropdown';
+					$atts['class']			= 'dropdown-toggle nav-link';
+					$atts['role']	= 'button';
+					$atts['aria-haspopup']	= 'true';
+				}
+				$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
+				$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+				$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+				$output .= $indent . '<li' . $id . $value . $class_names .'>';
+			}else{
+				$classes[] = 'dropdown-item';
+				$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
+				$atts['class'] = $class_names;
+				$atts['id'] = $id;
 			}
-
+			
 			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
 
 			$attributes = '';
@@ -101,21 +128,21 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			}
 
 			$item_output = $args->before;
-
+			$item_output .= '<a'. $attributes .'>';
+			
 			/*
-			 * Glyphicons
+			 * Icons
 			 * ===========
 			 * Since the the menu item is NOT a Divider or Header we check the see
 			 * if there is a value in the attr_title property. If the attr_title
-			 * property is NOT null we apply it as the class name for the glyphicon.
+			 * property is NOT null we apply it as the class name for the icon
 			 */
-			if ( ! empty( $item->attr_title ) )
-				$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
-			else
-				$item_output .= '<a'. $attributes .'>';
+			if ( ! empty( $item->attr_title ) ){
+				$item_output .= '<span class="' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
+			}
 
 			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
-			$item_output .= ( $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';
+			$item_output .= '</a>';
 			$item_output .= $args->after;
 
 			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
@@ -143,17 +170,17 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @return null Null on failure with no changes to parameters.
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-        if ( ! $element )
-            return;
+		if ( ! $element )
+			return;
 
-        $id_field = $this->db_fields['id'];
+		$id_field = $this->db_fields['id'];
 
-        // Display this element.
-        if ( is_object( $args[0] ) )
-           $args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
+		// Display this element.
+		if ( is_object( $args[0] ) )
+			$args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
 
-        parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
-    }
+		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
+	}
 
 	/**
 	 * Menu Fallback


### PR DESCRIPTION
Initial bootstrap v4.0.0 support (based on alpha 1 docs).

In general following has changed in bootstrap 4 and is reflected here:
- navbar <li> elements need a nav-item class
- navbar <a> elements need a nav-link class
- dropdown content is no longer a list, but are directly links
- dropdown headers have an h6-tag
- glyphicons are removed
