### PR TITLE
Link title managed by Title Attribute field

### DIFF
--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -76,7 +76,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$output .= $indent . '<li' . $id . $value . $class_names .'>';
 
 			$atts = array();
-			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
+			$atts['title']  = ! empty( $item->attr_title )	? $item->attr_title	: '';
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
 			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
 


### PR DESCRIPTION
Before the link attribute "title" was showing its _Navigation Label_.
Now the link attribute "title" is managed using the _Title Attribute_ field in admin.
