### PR TITLE
Add support for Font Awesome icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ wp-bootstrap-navwalker
 
 **A custom WordPress nav walker class to fully implement the Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.**
 
+![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
+
 Bootstrap 2.x vs Bootstrap 3.0
 ------------
 There are many changes Bootstrap 2.x & Bootstrap 3.0 that affect both how the nav walker class is used and what the walker supports. For CSS changes I recommend reading the Migrating from 2.x to 3.0 in the official Bootstrap docs http://getbootstrap.com/getting-started/#migration
@@ -100,15 +102,24 @@ Displaying the Menu
 -------------------
 To display the menu you must associate your menu with your theme location. You can do this by selecting your theme location in the *Theme Locations* list wile editing a menu in the WordPress menu manager.
 
+Extras
+------------
+
+![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
+
 This script included the ability to add Bootstrap dividers, dropdown headers, glyphicons and disables links to your menus through the WordPress menu UI. 
 
 Dividers
 ------------
 Simply add a Link menu item with a **URL** of `#` and a **Link Text** or **Title Attribute** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
 
+![Divider Example](http://edwardmcintyre.com/pub/github/navwalker-divider.jpg)
+
 Glyphicons
 ------------
 To add an Icon to your link simple place the Glyphicon class name in the links **Title Attribute** field and the class will do the rest. IE `glyphicon-bullhorn`
+
+![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-glyphicons.jpg)
 
 Font Awesome Fonts
 ------------
@@ -131,9 +142,13 @@ Dropdown Headers
 ------------
 Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.
 
+![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-header.jpg)
+
 Disabled Links
 ------------
 To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest. 
+
+![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-disabled.jpg)
 
 Changelog
 ------------
@@ -153,3 +168,5 @@ Changelog
 + Class was completly re-written using the latest Wordpress 3.6 walker class.
 + Now full supports Bootstrap 3.0+
 + Tested with wp_debug & the Theme Check plugin.
+
+[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/twittem/wp-bootstrap-navwalker/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ Dropdown Headers
 ------------
 Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.
 
-![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-header.jpg)
-
 Disabled Links
 ------------
 To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest. 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ wp-bootstrap-navwalker
 
 **A custom WordPress nav walker class to fully implement the Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.**
 
-![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
-
 Bootstrap 2.x vs Bootstrap 3.0
 ------------
 There are many changes Bootstrap 2.x & Bootstrap 3.0 that affect both how the nav walker class is used and what the walker supports. For CSS changes I recommend reading the Migrating from 2.x to 3.0 in the official Bootstrap docs http://getbootstrap.com/getting-started/#migration
@@ -102,24 +100,15 @@ Displaying the Menu
 -------------------
 To display the menu you must associate your menu with your theme location. You can do this by selecting your theme location in the *Theme Locations* list wile editing a menu in the WordPress menu manager.
 
-Extras
-------------
-
-![Extras](http://edwardmcintyre.com/pub/github/navwalker-3-menu.jpg)
-
 This script included the ability to add Bootstrap dividers, dropdown headers, glyphicons and disables links to your menus through the WordPress menu UI. 
 
 Dividers
 ------------
 Simply add a Link menu item with a **URL** of `#` and a **Link Text** or **Title Attribute** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
 
-![Divider Example](http://edwardmcintyre.com/pub/github/navwalker-divider.jpg)
-
 Glyphicons
 ------------
 To add an Icon to your link simple place the Glyphicon class name in the links **Title Attribute** field and the class will do the rest. IE `glyphicon-bullhorn`
-
-![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-glyphicons.jpg)
 
 Font Awesome Fonts
 ------------
@@ -148,8 +137,6 @@ Disabled Links
 ------------
 To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest. 
 
-![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-disabled.jpg)
-
 Changelog
 ------------
 **2.0.4**
@@ -168,5 +155,3 @@ Changelog
 + Class was completly re-written using the latest Wordpress 3.6 walker class.
 + Now full supports Bootstrap 3.0+
 + Tested with wp_debug & the Theme Check plugin.
-
-[![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/twittem/wp-bootstrap-navwalker/trend.png)](https://bitdeli.com/free "Bitdeli Badge")

--- a/README.md
+++ b/README.md
@@ -121,6 +121,23 @@ To add an Icon to your link simple place the Glyphicon class name in the links *
 
 ![Header Example](http://edwardmcintyre.com/pub/github/navwalker-3-glyphicons.jpg)
 
+Font Awesome Fonts
+------------
+To add [Font Awesome](http://www.fontawesome.io) fonts, simply add the Font Awesome CSS classes for your icon.
+
+Example:
+```css
+fa fa-twitter-square fa-2x
+```
+
+The `fa` is the class that will tell the walker to add an `<i>` tag containing the required Font Awesome attributes.
+
+By default, the Link Title is not shown. To show it, simply add the following CSS class:
+
+```css
+fa-show-title
+```
+
 Dropdown Headers
 ------------
 Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -78,7 +78,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$atts = array();
 			$atts['title']  = ! empty( $item->title )	? $item->title	: '';
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
-			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
+			$atts['rel']	= ! empty( $item->xfn )		? $item->xfn	: '';
 
 			// If item has_children add atts to a.
 			if ( $args->has_children && $depth === 0 ) {
@@ -108,45 +108,45 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			 * Since the the menu item is NOT a Divider or Header we check the see
 			 * if there is a value in the attr_title property. If the attr_title
 			 * property is NOT null we apply it as the class name for the glyphicon.
-             * If the attr_title contains 'fa' (the font awesome CSS class),
-             * then we omit the glyphicon and modify the link to add an <i> tag
-             * with the remaining attributes required by Font Awesome.
-             * If there is a css class named 'fa-show-title' in the 
-             * attr_title field, then the title will be shown next to the 
-             * font awesome font.
-             * See http://fontawesome.io/examples/ for more details on how to use 
-             * Font Awesome CSS classes.
-             *
-             * Here is an example of what the attr_title (Title Attribute) might look like for a Font Awesome font:
-             * (this is for a link to Twitter)
-             * fa fa-twitter-square fa-2x
-             *
-             * The 'fa-2x' class makes the font a little bigger and it fits better on the navbar.
+			 * If the attr_title contains 'fa' (the font awesome CSS class),
+			 * then we omit the glyphicon and modify the link to add an <i> tag
+			 * with the remaining attributes required by Font Awesome.
+			 * If there is a css class named 'fa-show-title' in the 
+			 * attr_title field, then the title will be shown next to the 
+			 * font awesome font.
+			 * See http://fontawesome.io/examples/ for more details on how to use 
+			 * Font Awesome CSS classes.
+			 *
+			 * Here is an example of what the attr_title (Title Attribute) might look like for a Font Awesome font:
+			 * (this is for a link to Twitter)
+			 * fa fa-twitter-square fa-2x
+			 *
+			 * The 'fa-2x' class makes the font a little bigger and it fits better on the navbar.
 			 */
-             
-             $font_awesome_class = 'fa';
-             $show_title_class = 'fa-show-title';
-             // we're going to show the title of the link by default
-             $show_title = true;
-             
+			 
+			 $font_awesome_class = 'fa';
+			 $show_title_class = 'fa-show-title';
+			 // we're going to show the title of the link by default
+			 $show_title = true;
+			 
 			if ( ! empty( $item->attr_title ) ) {
-                /* see if we have a font awesome font in the attr_title */
-                $attr_title_words = str_word_count($item->attr_title, 1);
-                if ( array_search ( $font_awesome_class , $attr_title_words) !== false ){
-                    $item_output .= '<a'. $attributes .'><i class="' . esc_attr( $item->attr_title ) . '"></i>';
-                    // we're not going to show the the title unless we have a 'show-title' class
-                    if ( ! array_search ( $show_title_class , $attr_title_words) ){
-                        $show_title = false;
-                    }
-                }
-                else{
-                    $item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';   
-                }   
-            }
+				/* see if we have a font awesome font in the attr_title */
+				$attr_title_words = str_word_count($item->attr_title, 1);
+				if ( array_search ( $font_awesome_class , $attr_title_words) !== false ){
+					$item_output .= '<a'. $attributes .'><i class="' . esc_attr( $item->attr_title ) . '"></i>';
+					// we're not going to show the the title unless we have a 'show-title' class
+					if ( ! array_search ( $show_title_class , $attr_title_words) ){
+						$show_title = false;
+					}
+				}
+				else{
+					$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';   
+				}   
+			}
 			else
 				$item_output .= '<a'. $attributes .'>';
-            
-            $link_title = $show_title ? apply_filters( 'the_title', $item->title, $item->ID ) : '';
+			
+			$link_title = $show_title ? apply_filters( 'the_title', $item->title, $item->ID ) : '';
 			$item_output .= $args->link_before . $link_title . $args->link_after;
 			$item_output .= ( $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';
 			$item_output .= $args->after;
@@ -176,17 +176,17 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 	 * @return null Null on failure with no changes to parameters.
 	 */
 	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
-        if ( ! $element )
-            return;
+		if ( ! $element )
+			return;
 
-        $id_field = $this->db_fields['id'];
+		$id_field = $this->db_fields['id'];
 
-        // Display this element.
-        if ( is_object( $args[0] ) )
-           $args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
+		// Display this element.
+		if ( is_object( $args[0] ) )
+		   $args[0]->has_children = ! empty( $children_elements[ $element->$id_field ] );
 
-        parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
-    }
+		parent::display_element( $element, $children_elements, $max_depth, $depth, $args, $output );
+	}
 
 	/**
 	 * Menu Fallback

--- a/wp_bootstrap_navwalker.php
+++ b/wp_bootstrap_navwalker.php
@@ -103,18 +103,51 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$item_output = $args->before;
 
 			/*
-			 * Glyphicons
+			 * Glyphicons and Font Awesome fonts
 			 * ===========
 			 * Since the the menu item is NOT a Divider or Header we check the see
 			 * if there is a value in the attr_title property. If the attr_title
 			 * property is NOT null we apply it as the class name for the glyphicon.
+             * If the attr_title contains 'fa' (the font awesome CSS class),
+             * then we omit the glyphicon and modify the link to add an <i> tag
+             * with the remaining attributes required by Font Awesome.
+             * If there is a css class named 'fa-show-title' in the 
+             * attr_title field, then the title will be shown next to the 
+             * font awesome font.
+             * See http://fontawesome.io/examples/ for more details on how to use 
+             * Font Awesome CSS classes.
+             *
+             * Here is an example of what the attr_title (Title Attribute) might look like for a Font Awesome font:
+             * (this is for a link to Twitter)
+             * fa fa-twitter-square fa-2x
+             *
+             * The 'fa-2x' class makes the font a little bigger and it fits better on the navbar.
 			 */
-			if ( ! empty( $item->attr_title ) )
-				$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
+             
+             $font_awesome_class = 'fa';
+             $show_title_class = 'fa-show-title';
+             // we're going to show the title of the link by default
+             $show_title = true;
+             
+			if ( ! empty( $item->attr_title ) ) {
+                /* see if we have a font awesome font in the attr_title */
+                $attr_title_words = str_word_count($item->attr_title, 1);
+                if ( array_search ( $font_awesome_class , $attr_title_words) !== false ){
+                    $item_output .= '<a'. $attributes .'><i class="' . esc_attr( $item->attr_title ) . '"></i>';
+                    // we're not going to show the the title unless we have a 'show-title' class
+                    if ( ! array_search ( $show_title_class , $attr_title_words) ){
+                        $show_title = false;
+                    }
+                }
+                else{
+                    $item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';   
+                }   
+            }
 			else
 				$item_output .= '<a'. $attributes .'>';
-
-			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+            
+            $link_title = $show_title ? apply_filters( 'the_title', $item->title, $item->ID ) : '';
+			$item_output .= $args->link_before . $link_title . $args->link_after;
 			$item_output .= ( $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';
 			$item_output .= $args->after;
 


### PR DESCRIPTION
I have added support for [Font Awesome](http://www.fontawesome.io) icons to the menu item link.

I needed to add social icons to my navbar, so I am using Font Awesome icons.

Here is a [Twitter icon](http://fontawesome.io/icon/twitter-square/) example.

From the new README:
## Font Awesome Fonts

To add [Font Awesome](http://www.fontawesome.io) fonts, simply add the Font Awesome CSS classes for your icon.

Example:

``` css
fa fa-twitter-square fa-2x
```

The `fa` is the class that will tell the walker to add an `<i>` tag containing the required Font Awesome attributes.

By default, the Link Title is not shown. To show it, simply add the following CSS class:

``` css
fa-show-title
```
