### PR TITLE
V4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [3.0.1]
 
+- Support `echo` arg in fallback menu.
+	- credit: @toddlevy
+
+## [3.0.1]
+
 - Fix to correct output of dropdown atts and styles when depth passed to wp_nav_menu is <= 1
 	- credit: @chrisgeary92
 - Move icon output to a local var instead of modifying and clearing a global object.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [3.0.2]
 
+- Remove `<span class="carat">` after parent dropdown items
 - Support `echo` arg in fallback menu.
 	- credit: @toddlevy
 - Add `.active` to parent when a child is current page.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 #CHANGELOG
 
-## [3.0.1]
+## [3.0.2]
 
 - Support `echo` arg in fallback menu.
 	- credit: @toddlevy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Support `echo` arg in fallback menu.
 	- credit: @toddlevy
+- Add `.active` to parent when a child is current page.
+	- credit: @zyberspace
 
 ## [3.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 #CHANGELOG
 
+## [3.0.1]
+
+- Fix to correct output of dropdown atts and styles when depth passed to wp_nav_menu is <= 1
+	- credit: @chrisgeary92
+- Move icon output to a local var instead of modifying and clearing a global object.
+- Reassign filtered classes back to $classes array so that updated classes can be accessed later if needed.
+	- credit: @lf-jeremy
+
 ## [3.0.0]
 
 - Update to work with Bootstrap v4.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code Coverage](https://scrutinizer-ci.com/g/wp-bootstrap/wp-bootstrap-navwalker/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/wp-bootstrap/wp-bootstrap-navwalker/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/wp-bootstrap/wp-bootstrap-navwalker/badges/build.png?b=master)](https://scrutinizer-ci.com/g/wp-bootstrap/wp-bootstrap-navwalker/build-status/master)
 
-A custom WordPress nav walker class to fully implement the Bootstrap 3.0+ navigation style in a custom theme using the WordPress built in menu manager.
+A custom WordPress nav walker class to fully implement the Bootstrap 4.0+ navigation style in a custom theme using the WordPress built in menu manager.
 
 ## NOTES
 
@@ -16,13 +16,13 @@ This is a utility class that is intended to format your WordPress theme menu wit
 
 ## Installation
 
-Place **wp-bootstrap-navwalker.php** in your WordPress theme folder `/wp-content/your-theme/`
+Place **class-wp-bootstrap-navwalker.php** in your WordPress theme folder `/wp-content/your-theme/`
 
 Open your WordPress themes **functions.php** file  `/wp-content/your-theme/functions.php` and add the following code:
 
 ```php
 // Register Custom Navigation Walker
-require_once('wp-bootstrap-navwalker.php');
+require_once('class-wp-bootstrap-navwalker.php');
 ```
 
 ## Usage
@@ -30,19 +30,18 @@ require_once('wp-bootstrap-navwalker.php');
 Update your `wp_nav_menu()` function in `header.php` to use the new walker by adding a "walker" item to the wp_nav_menu array.
 
 ```php
- <?php
-            wp_nav_menu( array(
-                'menu'              => 'primary',
-                'theme_location'    => 'primary',
-                'depth'             => 2,
-                'container'         => 'div',
-                'container_class'   => 'collapse navbar-collapse',
-                'container_id'      => 'bs-example-navbar-collapse-1',
-                'menu_class'        => 'nav navbar-nav',
-                'fallback_cb'       => 'WP_Bootstrap_Navwalker::fallback',
-                'walker'            => new WP_Bootstrap_Navwalker())
-            );
-        ?>
+<?php
+wp_nav_menu( array(
+    'theme_location'	=> 'primary',
+    'depth'				=> 2,
+	'container'			=> 'div',
+	'container_class'	=> 'collapse navbar-collapse',
+	'container_id'		=> 'bs-example-navbar-collapse-1'
+	'menu_class'		=> 'navbar-nav mr-auto',
+    'fallback_cb'		=> 'WP_Bootstrap_Navwalker::fallback',
+    'walker'			=> new WP_Bootstrap_Navwalker())
+);
+?>
 ```
 
 Your menu will now be formatted with the correct syntax and classes to implement Bootstrap dropdown navigation.
@@ -50,41 +49,32 @@ Your menu will now be formatted with the correct syntax and classes to implement
 You will also want to declare your new menu in your `functions.php` file.
 
 ```php
-register_nav_menus( array(
-        'primary' => __( 'Primary Menu', 'THEMENAME' ),
-) );
+	register_nav_menus( array(
+    	'primary' => __( 'Primary Menu', 'THEMENAME' ),
+	) );
 ```
 
-Typically the menu is wrapped with additional markup, here is an example of a ` navbar-fixed-top` menu that collapse for responsive navigation.
+Typically the menu is wrapped with additional markup, here is an example of a ` fixed-top` menu that collapse for responsive navigation at the md breakpoint.
 
 ```php
-<nav class="navbar navbar-default" role="navigation">
-  <div class="container-fluid">
+<nav class="navbar fixed-top navbar-toggleable-md navbar-light bg-faded" role="navigation">
+  <div class="container">
     <!-- Brand and toggle get grouped for better mobile display -->
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-        <span class="sr-only">Toggle navigation</span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-      <a class="navbar-brand" href="<?php echo home_url(); ?>">
-                <?php bloginfo('name'); ?>
-            </a>
-    </div>
-
+	<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-controls="bs-example-navbar-collapse-1" aria-expanded="false" aria-label="Toggle navigation">
+		<span class="navbar-toggler-icon"></span>
+	</button>
+	<a class="navbar-brand" href="#">Navbar</a>
         <?php
-            wp_nav_menu( array(
-                'menu'              => 'primary',
-                'theme_location'    => 'primary',
-                'depth'             => 2,
-                'container'         => 'div',
-                'container_class'   => 'collapse navbar-collapse',
-                'container_id'      => 'bs-example-navbar-collapse-1',
-                'menu_class'        => 'nav navbar-nav',
-                'fallback_cb'       => 'WP_Bootstrap_Navwalker::fallback',
-                'walker'            => new WP_Bootstrap_Navwalker())
-            );
+        wp_nav_menu( array(
+            'theme_location'    => 'primary',
+            'depth'             => 2,
+            'container'         => 'div',
+            'container_class'   => 'collapse navbar-collapse',
+            'container_id'      => 'bs-example-navbar-collapse-1',
+            'menu_class'        => 'nav navbar-nav',
+            'fallback_cb'       => 'WP_Bootstrap_Navwalker::fallback',
+            'walker'            => new WP_Bootstrap_Navwalker())
+        );
         ?>
     </div>
 </nav>
@@ -101,23 +91,15 @@ To display the menu you must associate your menu with your theme location. You c
 
 ### Extras
 
-This script included the ability to add Bootstrap dividers, dropdown headers, glyphicons and disables links to your menus through the WordPress menu UI.
+This script included the ability to use Bootstrap nav link mods in your menus through the WordPress menu UI. Currently only disabled links are supported. Additionally icon support is built-in for Glyphicons and font Awesome (note: you will need to include the icon stylesheets or assets separately)
 
-### Dividers
+#### Icons
 
-Simply add a Link menu item with a **URL** of `#` and a **Link Text** or **Title Attribute** of `divider` (case-insensitive so ‘divider’ or ‘Divider’ will both work ) and the class will do the rest.
+To add an Icon to your link simpley enter Glypicons or Font Awesome class names in the links **Classes** field in the Menu UI and the walker class will do the rest. IE `glyphicons glyphicons-bullhorn` or `fa fa-arrow-left`.
 
-### Glyphicons
+#### Disabled Links
 
-To add an Icon to your link simple place the Glyphicon class name in the links **Title Attribute** field and the class will do the rest. IE `glyphicon-bullhorn`
-
-### Dropdown Headers
-
-Adding a dropdown header is very similar, add a new link with a **URL** of `#` and a **Title Attribute** of `dropdown-header` (it matches the Bootstrap CSS class so it's easy to remember).  set the **Navigation Label** to your header text and the class will do the rest.
-
-### Disabled Links
-
-To set a disabled link simply set the **Title Attribute** to `disabled` and the class will do the rest.
+To set a disabled link simply add `disabled` to the **Classes** field in the Menu UI and the walker class will do the rest. Note: _In addition to adding the .disabled class this will change the link `href` to `#` as well so that it is not a followable link._
 
 ### Changelog
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$atts['target'] = ! empty( $item->target )	? $item->target	: '';
 			$atts['rel']    = ! empty( $item->xfn )		? $item->xfn	: '';
 			// If item has_children add atts to a.
-			if ( $args->has_children && 0 === $depth ) {
+			if ( $args->has_children && 0 === $depth && $args->depth > 1 ) {
 				$atts['href']   		= '#';
 				$atts['data-toggle']	= 'dropdown';
 				$atts['aria-haspopup']	= 'true';
@@ -154,7 +154,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$args->link_before = $args->link_before . '<i class="' . esc_attr( $icon_class_string ) . '"></i> ';
 			}
 			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
-			$item_output .= ( $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';
+			$item_output .= ( $args->has_children && 0 === $depth && $args->depth > 1 ) ? ' <span class="caret"></span></a>' : '</a>';
 			$item_output .= $args->after;
 			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -155,10 +155,10 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$icon_html = '';
 			if ( ! empty( $icon_class_string ) ) {
 				// append an <i> with the icon classes to what is output before links.
-				$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '"></i> ';
+				$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '" aria-hidden="true"></i> ';
 			}
 			$item_output .= $args->link_before . $icon_html . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
-			$item_output .= ( $args->has_children && 0 === $depth && $args->depth > 1 ) ? ' <span class="caret"></span></a>' : '</a>';
+			$item_output .= ( $args->has_children && 0 === $depth && $args->depth > 1 ) ? ' <span class="caret" aria-hidden="true"></span></a>' : '</a>';
 			$item_output .= $args->after;
 			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -90,7 +90,9 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$classes[] = 'menu-item-' . $item->ID;
 			// BSv4 classname - as of v4-alpha.
 			$classes[] = 'nav-item';
-			$class_names = join( ' ', apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args ) );
+			// reasign any filtered classes back to the $classes array.
+			$classes = apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args );
+			$class_names = join( ' ', $classes );
 			if ( $args->has_children ) {
 				$class_names .= ' dropdown';
 			}

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -237,7 +237,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$fallback_output = '<li><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" title="">' . esc_attr( 'Add a menu', '' ) . '</a></li>';
 				$fallback_output = '</ul>';
 				if ( $container ) {
-					$fb_output = '</' . esc_attr( $container ) . '>';
+					$fallback_output = '</' . esc_attr( $container ) . '>';
 				}
 
 				// if $args has 'echo' key and it's true echo, otherwise return.

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -11,7 +11,7 @@
  * Plugin URI:  https://github.com/wp-bootstrap/wp-bootstrap-navwalker
  * Description: A custom WordPress nav walker class to implement the Bootstrap 3 navigation style in a custom theme using the WordPress built in menu manager.
  * Author: Edward McIntyre - @twittem, WP Bootstrap, William Patton - @pattonwebz
- * Version: 3.0.
+ * Version: 3.0.2
  * Author URI: https://github.com/wp-bootstrap
  * GitHub Plugin URI: https://github.com/wp-bootstrap/wp-bootstrap-navwalker
  * GitHub Branch: master

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '" aria-hidden="true"></i> ';
 			}
 			$item_output .= $args->link_before . $icon_html . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
-			$item_output .= ( $args->has_children && 0 === $depth && $args->depth > 1 ) ? ' <span class="caret" aria-hidden="true"></span></a>' : '</a>';
+			$item_output .= '</a>';
 			$item_output .= $args->after;
 			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -11,7 +11,7 @@
  * Plugin URI:  https://github.com/wp-bootstrap/wp-bootstrap-navwalker
  * Description: A custom WordPress nav walker class to implement the Bootstrap 3 navigation style in a custom theme using the WordPress built in menu manager.
  * Author: Edward McIntyre - @twittem, WP Bootstrap, William Patton - @pattonwebz
- * Version: 3
+ * Version: 3.0.
  * Author URI: https://github.com/wp-bootstrap
  * GitHub Plugin URI: https://github.com/wp-bootstrap/wp-bootstrap-navwalker
  * GitHub Branch: master
@@ -215,26 +215,38 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$menu_class = $args['menu_class'];
 				$menu_id = $args['menu_id'];
 
+				// initialize var to store fallback html.
+				$fallback_output = '';
+
 				if ( $container ) {
-					echo '<' . esc_attr( $container );
+					$fallback_output = '<' . esc_attr( $container );
 					if ( $container_id ) {
-						echo ' id="' . esc_attr( $container_id ) . '"';
+						$fallback_output = ' id="' . esc_attr( $container_id ) . '"';
 					}
 					if ( $container_class ) {
-						echo ' class="' . sanitize_html_class( $container_class ) . '"'; }
-					echo '>';
+						$fallback_output = ' class="' . sanitize_html_class( $container_class ) . '"';
+					}
+					$fallback_output = '>';
 				}
-				echo '<ul';
+				$fallback_output = '<ul';
 				if ( $menu_id ) {
-					echo ' id="' . esc_attr( $menu_id ) . '"'; }
+					$fallback_output = ' id="' . esc_attr( $menu_id ) . '"'; }
 				if ( $menu_class ) {
-					echo ' class="' . esc_attr( $menu_class ) . '"'; }
-				echo '>';
-				echo '<li><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" title="">' . esc_attr( 'Add a menu', '' ) . '</a></li>';
-				echo '</ul>';
+					$fallback_output = ' class="' . esc_attr( $menu_class ) . '"'; }
+				$fallback_output = '>';
+				$fallback_output = '<li><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" title="">' . esc_attr( 'Add a menu', '' ) . '</a></li>';
+				$fallback_output = '</ul>';
 				if ( $container ) {
-					echo '</' . esc_attr( $container ) . '>'; }
-			}
+					$fb_output = '</' . esc_attr( $container ) . '>';
+				}
+
+				// if $args has 'echo' key and it's true echo, otherwise return.
+				if ( array_key_exists( 'echo', $args ) && $args['echo'] ) {
+					echo $fallback_output; // WPCS: XSS OK.
+				} else {
+					return $fallback_output;
+				}
+			} // End if().
 		}
 	}
 } // End if().

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -150,12 +150,14 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 			$item_output = $args->before;
 			$item_output .= '<a' . $attributes . '>';
-			// if we have a string containing icon classes...
+
+			// initiate empty icon var then if we have a string containing icon classes...
+			$icon_html = '';
 			if ( ! empty( $icon_class_string ) ) {
 				// append an <i> with the icon classes to what is output before links.
-				$args->link_before = $args->link_before . '<i class="' . esc_attr( $icon_class_string ) . '"></i> ';
+				$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '"></i> ';
 			}
-			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
+			$item_output .= $args->link_before . $icon_html . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
 			$item_output .= ( $args->has_children && 0 === $depth && $args->depth > 1 ) ? ' <span class="caret"></span></a>' : '</a>';
 			$item_output .= $args->after;
 			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			if ( $args->has_children ) {
 				$class_names .= ' dropdown';
 			}
-			if ( in_array( 'current-menu-item', $classes, true ) ) {
+			if ( in_array( 'current-menu-item', $classes, true ) || in_array( 'current-menu-parent', $classes, true ) ) {
 				$class_names .= ' active';
 			}
 			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -42,7 +42,14 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		 */
 		public function start_lvl( &$output, $depth = 0, $args = array() ) {
 			$indent = str_repeat( "\t", $depth );
-			$output .= "\n$indent<ul role=\"menu\" class=\" dropdown-menu\" >\n";
+			// find all links with an id in the output.
+			preg_match_all( '/(<a.*?id=\"|\')(.*?)\"|\'.*?>/im', $output, $matches );
+			// with pointer at end of array check if we got an ID match.
+			if ( end( $matches[2] ) ) {
+				// build a string to use as aria-labelledby.
+				$labledby = 'aria-labelledby="' . end( $matches[2] ) . '"';
+			}
+			$output .= "\n$indent<ul role=\"menu\" class=\" dropdown-menu\" " . $labledby . ">\n";
 		}
 
 		/**
@@ -120,6 +127,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$atts['aria-haspopup']	= 'true';
 				$atts['aria-expanded']	= 'false';
 				$atts['class']			= 'dropdown-toggle nav-link';
+				$atts['id']				= 'menu-item-dropdown-' . $item->ID;
 			} else {
 				$atts['href'] 	= ! empty( $item->url ) ? $item->url : '';
 				$atts['class']	= 'nav-link';


### PR DESCRIPTION
Fixes #249, Closes #268, Closes #101, Fixes #156, Closes #158. Closes #145 

#### Changes proposed in this Pull Request:

* Fix menus with depth of 1 from having dropdown atts and caret added.
* Assign filtered $classes back to the `$classes` array.
* Support for default `echo` arg in fallback function.
* Better accessibility for icons added via the class.
* Add `.active` to parent when a child is current page.
* Remove the `<span class="carat">` from fallback markup as no longer necessary.
