### PR TITLE
Fix error require file wp-bootstrap-navwalker

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if ( ! file_exists( get_template_directory() . '/wp-bootstrap-navwalker.php' ) )
 	return new WP_Error( 'wp-bootstrap-navwalker-missing', __( 'It appears the wp-bootstrap-navwalker.php file may be missing.', 'wp-bootstrap-navwalker' ) );
 } else {
 	// file exists... require it.
-    require_once get_template_directory . 'wp-bootstrap-navwalker.php';
+    require_once get_template_directory() . '/wp-bootstrap-navwalker.php';
 }
 ```
 


### PR DESCRIPTION
under "//file exists" require will error when only copy and paste the code

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
