### PR TITLE
Link title attribute for items with icons

### DIFF
--- a/wp-bootstrap-navwalker.php
+++ b/wp-bootstrap-navwalker.php
@@ -113,15 +113,15 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				} else {
 					$atts['href'] = ! empty( $item->url ) ? $item->url : '';
 				}
-				$atts       = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
+				$atts            = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
 				$icon_attributes = '';
-				$attributes = '';
+				$attributes      = '';
 				foreach ( $atts as $attr => $value ) {
 					if ( ! empty( $value ) ) {
 						$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
 						$attributes .= ' ' . $attr . '="' . $value . '"';
 						// if item has icon, we want all except title attributes because we
-						// want to avoid link title to be icon class
+						// want to avoid link title to be icon class.
 						if ( 'title' != $attr ) {
 							$icon_attributes .= ' ' . $attr . '="' . $value . '"';
 						}

--- a/wp-bootstrap-navwalker.php
+++ b/wp-bootstrap-navwalker.php
@@ -114,11 +114,17 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 					$atts['href'] = ! empty( $item->url ) ? $item->url : '';
 				}
 				$atts       = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
+				$icon_attributes = '';
 				$attributes = '';
 				foreach ( $atts as $attr => $value ) {
 					if ( ! empty( $value ) ) {
 						$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
 						$attributes .= ' ' . $attr . '="' . $value . '"';
+						// if item has icon, we want all except title attributes because we
+						// want to avoid link title to be icon class
+						if ( 'title' != $attr ) {
+							$icon_attributes .= ' ' . $attr . '="' . $value . '"';
+						}
 					}
 				}
 				$item_output = $args->before;
@@ -133,9 +139,9 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				if ( ! empty( $item->attr_title ) ) {
 					$pos = strpos( esc_attr( $item->attr_title ), 'glyphicon' );
 					if ( false !== $pos ) {
-						$item_output .= '<a' . $attributes . '><span class="glyphicon ' . esc_attr( $item->attr_title ) . '" aria-hidden="true"></span>&nbsp;';
+						$item_output .= '<a' . $icon_attributes . ' title="' . esc_attr( $item->title ) . '"><span class="glyphicon ' . esc_attr( $item->attr_title ) . '" aria-hidden="true"></span>&nbsp;';
 					} else {
-						$item_output .= '<a' . $attributes . '><i class="fa ' . esc_attr( $item->attr_title ) . '" aria-hidden="true"></i>&nbsp;';
+						$item_output .= '<a' . $icon_attributes . ' title="' . esc_attr( $item->title ) . '"><i class="fa ' . esc_attr( $item->attr_title ) . '" aria-hidden="true"></i>&nbsp;';
 					}
 				} else {
 					$item_output .= '<a' . $attributes . '>';


### PR DESCRIPTION
When icon is added to item its link has icon's class as title attribute, while without icon it's item's title. Link's title should remain item's title, regardless of icon being included or not.

At the moment it is like this:

```
<a href="" title="fa-star-o">
	<i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;Title
</a>
```

And it should be like this:

```
<a href="" title="Title">
	<i class="fa fa-star-o" aria-hidden="true"></i>&nbsp;Title
</a>
```

