### PR TITLE
fix variable name typo (which throws a Notice if WP_DEBUG==true)

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -74,9 +74,9 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			// with pointer at end of array check if we got an ID match.
 			if ( end( $matches[2] ) ) {
 				// build a string to use as aria-labelledby.
-				$lablledby = 'aria-labelledby="' . end( $matches[2] ) . '"';
+				$labelledby = 'aria-labelledby="' . end( $matches[2] ) . '"';
 			}
-			$output .= "{$n}{$indent}<ul$class_names $lablledby role=\"menu\">{$n}";
+			$output .= "{$n}{$indent}<ul$class_names $labelledby role=\"menu\">{$n}";
 		}
 
 		/**


### PR DESCRIPTION
Fixes *n/a - no issue reported, simple fix*

#### Changes proposed in this Pull Request:

* Fix spelling of the variable `$labelledby`. It is initialized in line 71, later misspelled as `$lablledby`.

#### Testing instructions:

Running the example code with `WP_DEBUG=true` throws

```
**Notice:**  Undefined variable: lablledby in **…/wp-bootstrap/wp-bootstrap-navwalker/class-wp-bootstrap-navwalker.php** on line **79**
```

// sorry if this PR is not perfect, it's my first ever :)