### PR TITLE
Fixing incorrect reference to navwalker class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/wp-bootstrap/wp-bootstrap-navwalker/"
     },
     "autoload": {
-    "files": ["class-wp-bootstrap-navwalker.php"]
+    "files": ["wp-bootstrap-navwalker.php"]
     },
     "require": {
       "composer/installers": "~1.0"


### PR DESCRIPTION
Fixes #350

Changes proposed in this Pull Request:
Fix error with version 3.0.2 when requiring package via composer.

Testing instructions:
Import package composer composer require wp-bootstrap/wp-bootstrap-navwalker and use normally. No errors should occur.

Proposed changelog entry for your changes:
Fixed incorrect autoloading bug in composer.json