### PR TITLE
Depth param added filter `nav_menu_link_attributes`

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -201,7 +201,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			// update atts of this item based on any custom linkmod classes.
 			$atts = self::update_atts_for_linkmod_type( $atts, $linkmod_classes );
 			// Allow filtering of the $atts array before using it.
-			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
+			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
 
 			// Build a string of html containing all the atts for the item.
 			$attributes = '';


### PR DESCRIPTION
`$depth` added as 4th parameter of the filter hook
`nav_menu_link_attributes`, this to allow more customization for deeper
sub items.

Fixes #

#### Changes proposed in this Pull Request:

* Adds `$depth` parameter to filter hook `nav_menu_link_attributes` to allow better customization.

#### Testing instructions:

* Use hook in wordpress.
