### PR TITLE
Fixed parse error: syntax error, unexpected '$item_output' on line 150

### DIFF
--- a/wp-bootstrap-navwalker.php
+++ b/wp-bootstrap-navwalker.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				} else {
 					$item_output .= '<a' . $attributes . '>';
 				}
-				$item_output .= isset( $args->link_before ) ? $args->link_before : ''
+				$item_output .= isset( $args->link_before ) ? $args->link_before : '';
 				$item_output .= apply_filters( 'the_title', $item->title, $item->ID );
 				$item_output .= isset( $args->link_after ) ? $args->link_after: '';
 				$item_output .= ( isset( $args->has_children ) && $args->has_children && 0 === $depth ) ? ' <span class="caret"></span></a>' : '</a>';


### PR DESCRIPTION
Fixes #372 

#### Changes proposed in this Pull Request:

* Added missing ; at the end of line 149 that causes parse error.

#### Testing instructions:

* Place "old" wp-bootstrap-navwalker.php in your WordPress theme folder /wp-content/your-theme/ and load page. You should get: Parse error: syntax error, unexpected '$item_output' (T_VARIABLE) in /Applications/MAMP/htdocs/wpdev/wp-content/themes/pressite/inc/wp-bootstrap-navwalker.php on line 150 error is shown. 
* Place fixed version of file there not should be an error any more.