### PR TITLE
schema markup addition

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		 */
 		public function __construct() {
 			if ( ! has_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] ) ) {
-				add_filter( 'wp_nav_menu_args',  [ $this, 'add_schema_to_navbar_ul' ] );
+				add_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] );
 			}
 		}
 
@@ -419,7 +419,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		public function add_schema_to_navbar_ul( $args ) {
 			$wrap = $args['items_wrap'];
 			if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
-				$args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', ' itemscope itemtype="http://www.schema.org/SiteNavigationElement"'."$0", $wrap );
+				$args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', ' itemscope itemtype="http://www.schema.org/SiteNavigationElement"$0', $wrap );
 			}
 
 			return $args;

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		 * Whether the items_wrap contains schema microdata or not.
 		 *
 		 * @since 4.2.0
-		 * @var type boolean
+		 * @var boolean
 		 */
 		private $has_schema = false;
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -28,24 +28,24 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 	 */
 	class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 
-	    /**
-	     * Whether the items_wrap contains schema microdata or not.
-	     * 
-	     * @since 4.2.0
-	     * @var type bool
-	     */
-	    private $has_schema = false;
+		/**
+		 * Whether the items_wrap contains schema microdata or not.
+		 *
+		 * @since 4.2.0
+		 * @var type bool
+		 */
+		private $has_schema = false;
 
-	    /**
-	     * Ensure the items_wrap argument contains microdata.
-	     *
-	     * @since 4.2.0
-	     */
-	    public function __construct() {
-	        if ( ! has_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] ) ) {
-	            add_filter( 'wp_nav_menu_args',  [ $this, 'add_schema_to_navbar_ul' ] );
-	        }
-	    }
+		/**
+		 * Ensure the items_wrap argument contains microdata.
+		 *
+		 * @since 4.2.0
+		 */
+		public function __construct() {
+			if ( ! has_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] ) ) {
+				add_filter( 'wp_nav_menu_args',  [ $this, 'add_schema_to_navbar_ul' ] );
+			}
+		}
 
 		/**
 		 * Starts the list before the elements are added.
@@ -122,11 +122,11 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 			$indent = ( $depth ) ? str_repeat( $t, $depth ) : '';
 
-			if ( strpos( $args->items_wrap, 'itemscope' ) !== false && $this->has_schema === false ) {
-	            $this->has_schema = true;
-	            $args->link_before = '<span itemprop="name">' . $args->link_before;
-	            $args->link_after .= '</span>';
-	        }
+			if ( false !== strpos( $args->items_wrap, 'itemscope' ) && false === $this->has_schema ) {
+				$this->has_schema  = true;
+				$args->link_before = '<span itemprop="name">' . $args->link_before;
+				$args->link_after .= '</span>';
+			}
 
 			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 
@@ -215,8 +215,8 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$atts['id']            = 'menu-item-dropdown-' . $item->ID;
 			} else {
 				if ( $this->has_schema === true ) {
-	        		$atts['itemprop'] = 'url';
-	        	}
+					$atts['itemprop'] = 'url';
+				}
 
 				$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
 				// Items in dropdowns use .dropdown-item instead of .nav-link.
@@ -409,21 +409,21 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		}
 
 		/**
-	     * Filter to ensure the items_Wrap argument contains microdata.
-	     *
-	     * @since 4.2.0
-	     *
-	     * @param  array $args The nav instance arguments.
-	     * @return array $args The altered nav instance arguments.
-	     */
-	    public function add_schema_to_navbar_ul( $args ) {
-	        $wrap = $args['items_wrap'];
-	        if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
-	            $args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', " itemscope itemtype=\"http://www.schema.org/SiteNavigationElement\"$0", $wrap );
-	        }
+		 * Filter to ensure the items_Wrap argument contains microdata.
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param  array $args The nav instance arguments.
+		 * @return array $args The altered nav instance arguments.
+		 */
+		public function add_schema_to_navbar_ul( $args ) {
+			$wrap = $args['items_wrap'];
+			if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
+				$args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', ' itemscope itemtype="http://www.schema.org/SiteNavigationElement"'."$0", $wrap );
+			}
 
-	        return $args;
-	    }
+			return $args;
+		}
 
 		/**
 		 * Find any custom linkmod or icon classes and store in their holder

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -32,7 +32,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		 * Whether the items_wrap contains schema microdata or not.
 		 *
 		 * @since 4.2.0
-		 * @var type bool
+		 * @var type boolean
 		 */
 		private $has_schema = false;
 
@@ -214,7 +214,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$atts['class']         = 'dropdown-toggle nav-link';
 				$atts['id']            = 'menu-item-dropdown-' . $item->ID;
 			} else {
-				if ( $this->has_schema === true ) {
+				if ( true === $this->has_schema ) {
 					$atts['itemprop'] = 'url';
 				}
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -42,8 +42,8 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 		 * @since 4.2.0
 		 */
 		public function __construct() {
-			if ( ! has_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] ) ) {
-				add_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] );
+			if ( ! has_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) ) ) {
+				add_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) );
 			}
 		}
 

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -28,6 +28,25 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 	 */
 	class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 
+	    /**
+	     * Whether the items_wrap contains schema microdata or not.
+	     * 
+	     * @since 4.2.0
+	     * @var type bool
+	     */
+	    private $has_schema = false;
+
+	    /**
+	     * Ensure the items_wrap argument contains microdata.
+	     *
+	     * @since 4.2.0
+	     */
+	    public function __construct() {
+	        if ( ! has_filter( 'wp_nav_menu_args', [ $this, 'add_schema_to_navbar_ul' ] ) ) {
+	            add_filter( 'wp_nav_menu_args',  [ $this, 'add_schema_to_navbar_ul' ] );
+	        }
+	    }
+
 		/**
 		 * Starts the list before the elements are added.
 		 *
@@ -103,6 +122,12 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 			$indent = ( $depth ) ? str_repeat( $t, $depth ) : '';
 
+			if ( strpos( $args->items_wrap, 'itemscope' ) !== false && $this->has_schema === false ) {
+	            $this->has_schema = true;
+	            $args->link_before = '<span itemprop="name">' . $args->link_before;
+	            $args->link_after .= '</span>';
+	        }
+
 			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 
 			// Initialize some holder variables to store specially handled item
@@ -165,7 +190,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
 			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
-			$output .= $indent . '<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement"' . $id . $class_names . '>';
+			$output .= $indent . '<li ' . $id . $class_names . '>';
 
 			// initialize array for holding the $atts for the link item.
 			$atts = array();
@@ -189,6 +214,10 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$atts['class']         = 'dropdown-toggle nav-link';
 				$atts['id']            = 'menu-item-dropdown-' . $item->ID;
 			} else {
+				if ( $this->has_schema === true ) {
+	        		$atts['itemprop'] = 'url';
+	        	}
+
 				$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
 				// Items in dropdowns use .dropdown-item instead of .nav-link.
 				if ( $depth > 0 ) {
@@ -200,6 +229,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 
 			// update atts of this item based on any custom linkmod classes.
 			$atts = self::update_atts_for_linkmod_type( $atts, $linkmod_classes );
+
 			// Allow filtering of the $atts array before using it.
 			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
 
@@ -377,6 +407,23 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				}
 			}
 		}
+
+		/**
+	     * Filter to ensure the items_Wrap argument contains microdata.
+	     *
+	     * @since 4.2.0
+	     *
+	     * @param  array $args The nav instance arguments.
+	     * @return array $args The altered nav instance arguments.
+	     */
+	    public function add_schema_to_navbar_ul( $args ) {
+	        $wrap = $args['items_wrap'];
+	        if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
+	            $args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', " itemscope itemtype=\"http://www.schema.org/SiteNavigationElement\"$0", $wrap );
+	        }
+
+	        return $args;
+	    }
 
 		/**
 		 * Find any custom linkmod or icon classes and store in their holder


### PR DESCRIPTION
Fixes #261 

#### Changes proposed in this Pull Request:

* Just the obvious changes - schema markup has been added to the parent element, the `<a/>` tags, and a span surrounding the anchor content. 
* Bump up version to 4.2.0 (I noticed 4.1.0 was not the most recent version, but the most recent tag seems to be erroneous?).

#### Testing instructions:

So it's a 'hands in the air/guilty' kinda moment here. I don't have phpunit/phpcs installed globally as I always use composer to install and run on a project by project basis. As a result I haven't updated any of the tests 👎 . 

If this is a huge issue, you will have to bear with me as this PC is Windows (which doesn't play nice with the WP-CLI .sh file you have in the bin directory), and is currently running PHP 7.0.* which would involve either updating the PHP version (never fun on windows), or using some archaic version of the testing stack with 7.0.* as the minimum version.

If it is a big problem, say so and I can move the code onto my laptop to run PHPCS. Again, it is Windows - so you may have to give me pointers on getting the test suite working correctly.

It is also worth mentioning, that because of the above testing/standards issues, I did not want to push to `master`, but cannot see a development branch?

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Added SiteNavigationElement schema microdata
