### PR TITLE
Display url on dropdown

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';
 			// If item has_children add atts to <a>.
 			if ( isset( $args->has_children ) && $args->has_children && 0 === $depth && $args->depth > 1 ) {
-				$atts['href']          = '#';
+				$atts['href']          = ! empty( $item->url ) ? $item->url : '#';
 				$atts['data-toggle']   = 'dropdown';
 				$atts['aria-haspopup'] = 'true';
 				$atts['aria-expanded'] = 'false';


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When item is dropdown, display url in href rather # . Like that, it will be easy to override bootstrap dropdown behavior if we want. For example, if I want a hover (it's not walker work but javascript implementation) on dropdown, I need sometimes to get link when click on dropdown item.

#### Testing instructions:

* Not especially. But you can try to click on dropdown, dropdown work even if not # but link. But if you disable dropdown effect, you can click on link !

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Ability to get link on dropdown item
