### PR TITLE
Fix bug in the WordPress Customizer preview related to the CSS classe…

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -105,6 +105,13 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 
 			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 
+			// Updating the CSS classes of a menu item in the WordPress Customizer preview results in all classes defined
+			// in that particular input box to come in as one big class string.
+			$split_on_spaces = function ( $class ) {
+				return preg_split( '/\s+/', $class );
+			};
+			$classes         = flatten( array_map( $split_on_spaces, $classes ) );
+
 			// Initialize some holder variables to store specially handled item
 			// wrappers and icons.
 			$linkmod_classes = array();
@@ -551,5 +558,24 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 			return $output;
 		}
+	}
+
+	/**
+	 * Flattens a multidimensional array to a simple array.
+	 *
+	 * @param array $array a multidimensional array.
+	 *
+	 * @return array a simple array
+	 */
+	function flatten( $array ) {
+		$result = array();
+		foreach ( $array as $element ) {
+			if ( is_array( $element ) ) {
+				array_push( $result, ...flatten( $element ) );
+			} else {
+				$result[] = $element;
+			}
+		}
+		return $result;
 	}
 }


### PR DESCRIPTION
When you update the CSS classes of a menu item in the WordPress Customizer preview, it results in all classes defined in that input box to come in as one big class string.

<img width="299" alt="screen shot 2019-01-26 at 18 27 58" src="https://user-images.githubusercontent.com/6907423/51790645-739e2380-2198-11e9-90a7-4e8c0135c347.png">

So in this case, wp-bootstrap-navwalker receives "fa fa-fw fa-user" as one class string.

This PR attempts to work around that problem.

