### PR TITLE
fix title attribute on line 224

### DIFF
--- a/wp-bootstrap-navwalker.php
+++ b/wp-bootstrap-navwalker.php
@@ -221,7 +221,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				if ( $menu_class ) {
 					echo ' class="' . esc_attr( $menu_class ) . '"'; }
 				echo '>';
-				echo '<li><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" title="">' . esc_attr( 'Add a menu', '' ) . '</a></li>';
+				echo '<li><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" title="' . esc_attr( 'Add a menu', '' ) . '"</a></li>';
 				echo '</ul>';
 				if ( $container ) {
 					echo '</' . esc_attr( $container ) . '>'; }


### PR DESCRIPTION
There's an empty title attribute on line 224 reported by the Theme Check plugin:
`title="">' . esc_attr( 'Add a menu', '' ) . '`
Should be:
`title="' . esc_attr( 'Add a menu', '' ) . '"`
