### PR TITLE
Remove esc_html() from $item->title

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -245,7 +245,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			/** This filter is documented in wp-includes/post-template.php */
-			$title = apply_filters( 'the_title', esc_html( $item->title ), $item->ID );
+			$title = apply_filters( 'the_title', $item->title, $item->ID );
 
 			/**
 			 * Filters a menu item's title.


### PR DESCRIPTION
Removes esc_html() from $item->title since the use of HTML in the title is allowed. See #417 for an example on how esc_html leads to undesired results.

If theme developers decide to not allow HTML in the title they could and should use the the_title filter hook for escaping. 