### PR TITLE
Add WPML detection

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -247,16 +247,16 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			/** This filter is documented in wp-includes/post-template.php */
-			if ( $item -> type == "wpml_ls_menu_item" ) {
-				if ( strpos( $item -> title, 'wpml-ls-flag' ) > 0 ) {
-					$title = $item -> title;
+			if ($item->type === 'wpml_ls_menu_item') {
+				if (strpos($item->title, 'wpml-ls-flag') > 0) {
+					$title = $item->title;
 				} else {
-					$title = strip_tags( $item -> title );
+					$title = strip_tags($item->title);
 				}
 			} else {
-				$title = esc_html( $item -> title );
+				$title = esc_html($item->title);
 			}
-			$title = apply_filters( 'the_title', $title, $item -> ID );
+			$title = apply_filters('the_title', $title, $item->ID);
 
 			/**
 			 * Filters a menu item's title.

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -247,7 +247,16 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			/** This filter is documented in wp-includes/post-template.php */
-			$title = apply_filters( 'the_title', esc_html( $item->title ), $item->ID );
+			if ( $item -> type == "wpml_ls_menu_item" ) {
+				if ( strpos( $item -> title, 'wpml-ls-flag' ) > 0 ) {
+					$title = $item -> title;
+				} else {
+					$title = strip_tags( $item -> title );
+				}
+			} else {
+				$title = esc_html( $item -> title );
+			}
+			$title = apply_filters( 'the_title', $title, $item -> ID );
 
 			/**
 			 * Filters a menu item's title.


### PR DESCRIPTION
Add menu item type checking for WPML support. 

When using the WPML plugin while using this nav walker, the menu item is displayed with escaped HTML instead of just outputting HTML. If the menu item does not contain a flag, we can safely strip all HTML tags

Fixes #

#### Changes proposed in this Pull Request:

* Added 'wpml-ls-flag' check in the menu item title to ensure flags are displayed correctly, otherwise just strip tags. If the menu item type is not 'wpml_ls_menu_item', just escape the html

#### Testing instructions:

* Use this nav walker while adding a WPML language switcher to the same menu.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
