### PR TITLE
Add accessibility role attributes to li and a elements

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -166,7 +166,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
 			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
 
-			$output .= $indent . '<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement"' . $id . $class_names . '>';
+			$output .= $indent . '<li role="none" itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement"' . $id . $class_names . '>';
 
 			// Initialize array for holding the $atts for the link item.
 			$atts = array();
@@ -232,7 +232,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 				$item_output .= self::linkmod_element_open( $linkmod_type, $attributes );
 			} else {
 				// With no link mod type set this must be a standard <a> tag.
-				$item_output .= '<a' . $attributes . '>';
+				$item_output .= '<a role="menuitem"' . $attributes . '>';
 			}
 
 			/*


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Add li and a menu elements role attributes in accordance with accessibility best practices. See https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html 

#### Testing instructions:

Scan with - https://wave.webaim.org/
