### PR TITLE
do not escape html in menu item title

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -247,7 +247,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			}
 
 			/** This filter is documented in wp-includes/post-template.php */
-			$title = apply_filters( 'the_title', esc_html( $item->title ), $item->ID );
+			$title = apply_filters( 'the_title', $item->title, $item->ID );
 
 			/**
 			 * Filters a menu item's title.

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -421,6 +421,10 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 					// Glyphicons.
 					$icon_classes[] = $class;
 					unset( $classes[ $key ] );
+				} elseif ( preg_match( '/^cm-icon-(\S*)?/i', $class ) ) {
+					// Custom icons.
+					$icon_classes[] = $class;
+					unset( $classes[ $key ] );
 				}
 			}
 


### PR DESCRIPTION
The following code wouldn't work when escaping html in the title attribute (using ACF plugin):
```php
function my_wp_nav_menu_objects($items, $args) {
	foreach ($items as &$item) {
		$image = get_field('image', $item);

		if ($image) {
			$item->title = '<img alt="' . $item->title . '" class="img-fluid" src="' . $image . '" title="' . $item->title . '" />';
		}
	}

	return $items;
}
add_filter('wp_nav_menu_objects', 'my_wp_nav_menu_objects', 10, 2);
```

Removing `esc_html` fixes it.