### PR TITLE
Drop default value for title attribute

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -171,15 +171,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			// Initialize array for holding the $atts for the link item.
 			$atts = array();
 
-			/*
-			 * Set title from item to the $atts array - if title is empty then
-			 * default to item title.
-			 */
-			if ( empty( $item->attr_title ) ) {
-				$atts['title'] = ! empty( $item->title ) ? strip_tags( $item->title ) : '';
-			} else {
-				$atts['title'] = $item->attr_title;
-			}
+			$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
 
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
 			$atts['rel']    = ! empty( $item->xfn ) ? $item->xfn : '';


### PR DESCRIPTION
Setting the title attribute to the item title if empty 
a) just duplicates information which is already there,
b) does not what the title attribute is intended to do (giving advisory information related to the element it belongs to),
c) may cause accessibility issues (see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title#Accessibility_concerns),
an thus should be dropped completely instead of providing the option to turn it off as proposed in #448.

I guess, it is also what people expect the walker to do when there is no user input.

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
