### PR TITLE
Add `role="menuitem"` to all dropdown menu items

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -165,8 +165,11 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) {
 			 */
 			$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
 			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+			
+			// Add role attribute if menu item is part of a submenu
+			$role = $depth > 0 ? ' role="menuitem"' : '';
 
-			$output .= $indent . '<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement"' . $id . $class_names . '>';
+			$output .= $indent . '<li itemscope="itemscope" itemtype="https://www.schema.org/SiteNavigationElement"' . $id . $role . $class_names . '>';
 
 			// Initialize array for holding the $atts for the link item.
 			$atts = array();


### PR DESCRIPTION
This solves accessibility checker issue that all menus with `role="menu"` have at least one child element with `role="menuitem"`.

https://web.dev/aria-required-children/?utm_source=lighthouse&utm_medium=devtools

#### Changes proposed in this Pull Request:

* Adds `role="menuitem"` to all dropdown menu items

#### Testing instructions:

* Create a menu with a submenu, all submenu menu items should have a `role` attribute with the value `menuitem`.
