### PR TITLE
Remove role="menu"

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 				// Build a string to use as aria-labelledby.
 				$labelledby = 'aria-labelledby="' . esc_attr( end( $matches[2] ) ) . '"';
 			}
-			$output .= "{$n}{$indent}<ul$class_names $labelledby role=\"menu\">{$n}";
+			$output .= "{$n}{$indent}<ul$class_names $labelledby>{$n}";
 		}
 
 		/**
@@ -197,9 +197,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			$atts = array();
 
 			$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
-
 			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-
 			if ( '_blank' === $item->target && empty( $item->xfn ) ) {
 				$atts['rel'] = 'noopener noreferrer';
 			} else {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Removes `role="menu"` from `<ul>` tag in `start_lvl()`.
Bootstrap follows the [disclosure design pattern](https://w3c.github.io/aria-practices/examples/disclosure/disclosure-navigation.html) which does not use any menu related aria roles. See https://github.com/wp-bootstrap/wp-bootstrap-navwalker/pull/456#issuecomment-661602093 for more details.

Closes PR #456 and #475.