### PR TITLE
Use PHPUnit 5 instead of PHPUnit 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ php:
   - nightly
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.6"
-  - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.6"
+  - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
+  - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
 
 services:
   - mysql
@@ -24,19 +24,19 @@ jobs:
     - php: 7.0
       dist: xenial
       env:
-        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.6"
+        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
     - php: 7.0
       dist: xenial
       env:
-        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.6"
+        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
     - php: 5.6
       dist: xenial
       env:
-        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="4.8.*"
+        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
     - php: 5.6
       dist: xenial
       env:
-        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="4.8.*"
+        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
     - name: "Coding Standars"
       php: 7.4
       install:


### PR DESCRIPTION
Builds using PHPUnit 4 fail (see [here](https://travis-ci.org/github/wp-bootstrap/wp-bootstrap-navwalker/jobs/718011844)) because WordPress requires at least PHPUnit 5.4. Thrown Error: "Looks like you're using PHPUnit 4.8.36. WordPress requires at least PHPUnit 5.4 and is currently only compatible with PHPUnit up to 7.x.". 

#### Changes proposed in this Pull Request:

* Use PHPUnit 5 instead of PHPUnit 4