### PR TITLE
Add `container_aria_label` argument

### DIFF
--- a/tests/phpstan/class-wp-nav-menu-args.php
+++ b/tests/phpstan/class-wp-nav-menu-args.php
@@ -56,6 +56,14 @@ class WP_Nav_Menu_Args {
 	public $container_id;
 
 	/**
+	 * The aria-label attribute that is applied to the container
+	 * when it's a nav element. Default empty.
+	 *
+	 * @var string
+	 */
+	public $container_aria_label;
+
+	/**
 	 * If the menu doesn't exists, a callback function will fire.
 	 * Default is 'wp_page_menu'. Set to false for no fallback.
 	 *


### PR DESCRIPTION
Adds `container_aria_label` argument to tests/phpstan/class-wp-nav-menu-args.php. The argument has been added in [WP 5.5.0](https://core.trac.wordpress.org/browser/tags/5.5/src/wp-includes/nav-menu-template.php#L18). This does not fix [PHPStan errors](https://travis-ci.org/github/wp-bootstrap/wp-bootstrap-navwalker/jobs/756252157).