### PR TITLE
Create dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UCT
+    open-pull-requests-limit: 5
+    versioning-strategy: increase


### PR DESCRIPTION
Adds a [Dependabot config file](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates) which tells [Dependabot](https://github.com/dependabot) to weekly check for composer dependency updates. If Dependabot finds updates it will make a PR.

@pattonwebz Maybe one has to enable Dependabot for the repo to make this work.