### PR TITLE
Travis config: remove unit tests for multisite env, add PHP 8.0, fix typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 dist: bionic
 
 php:
+  - 8.0
   - 7.4
   - 7.3
   - 7.2
@@ -13,8 +14,7 @@ php:
   - nightly
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
-  - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
+  - WP_VERSION=latest PHPUNIT_VERSION="^5.7"
 
 services:
   - mysql
@@ -23,21 +23,9 @@ jobs:
   include:
     - php: 7.0
       dist: xenial
-      env:
-        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
-    - php: 7.0
-      dist: xenial
-      env:
-        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
     - php: 5.6
       dist: xenial
-      env:
-        - WP_VERSION=latest WP_MULTISITE=0 PHPUNIT_VERSION="^5.7"
-    - php: 5.6
-      dist: xenial
-      env:
-        - WP_VERSION=latest WP_MULTISITE=1 PHPUNIT_VERSION="^5.7"
-    - name: "Coding Standars"
+    - name: "Coding Standards"
       php: 7.4
       install:
         - composer require --dev wp-coding-standards/wpcs dealerdirect/phpcodesniffer-composer-installer


### PR DESCRIPTION
Fixes #511

#### Changes proposed in this Pull Request:

* Removes unit test for multisite environment. See #511.
* Adds PHP 8.0 as nightly is now 8.1
* Fixes a typo

#### Testing instructions:

*

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Update Travis config