### PR TITLE
Remove aria-haspopup from dropdowns

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -214,7 +214,6 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			if ( $this->has_children && 0 === $depth ) {
 				$atts['href']          = '#';
 				$atts['data-toggle']   = 'dropdown';
-				$atts['aria-haspopup'] = 'true';
 				$atts['aria-expanded'] = 'false';
 				$atts['class']         = 'dropdown-toggle nav-link';
 				$atts['id']            = 'menu-item-dropdown-' . $item->ID;


### PR DESCRIPTION
> `aria-haspopup="true"` is really intended to signal that an ARIA `menu` will be opened on activation. as a result, some assistive technologies will announce controls with `aria-haspopup="true"` as a menu or menu item (e.g. JAWS and NVDA). In addition, `aria-haspopup` seems to trigger a bug in Edge/Narrator where the `aria-expanded` state is not correctly announced at the moment when `aria-haspopup` is present. This now makes the dropdown button more like a generic disclosure widget control - see also https://www.w3.org/TR/wai-aria-practices-1.2/examples/disclosure/disclosure-navigation.html01

See https://github.com/twbs/bootstrap/pull/33624#issue-857305617

#### Changes proposed in this Pull Request:

* Removes aria-haspopup from dropdowns

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Remove aria-haspopup from dropdowns