### PR TITLE
Fix non static method calls

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -147,7 +147,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			 * NOTE: linkmod and icon class arrays are passed by reference and
 			 * are maybe modified before being used later in this function.
 			 */
-			$classes = self::separate_linkmods_and_icons_from_classes( $classes, $linkmod_classes, $icon_classes, $depth );
+			$classes = $this->separate_linkmods_and_icons_from_classes( $classes, $linkmod_classes, $icon_classes, $depth );
 
 			// Join any icon classes plucked from $classes into a string.
 			$icon_class_string = join( ' ', $icon_classes );
@@ -234,7 +234,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			$atts['aria-current'] = $item->current ? 'page' : '';
 
 			// Update atts of this item based on any custom linkmod classes.
-			$atts = self::update_atts_for_linkmod_type( $atts, $linkmod_classes );
+			$atts = $this->update_atts_for_linkmod_type( $atts, $linkmod_classes );
 
 			// Allow filtering of the $atts array before using it.
 			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
@@ -249,7 +249,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			}
 
 			// Set a typeflag to easily test if this is a linkmod or not.
-			$linkmod_type = self::get_linkmod_type( $linkmod_classes );
+			$linkmod_type = $this->get_linkmod_type( $linkmod_classes );
 
 			// START appending the internal item contents to the output.
 			$item_output = isset( $args->before ) ? $args->before : '';
@@ -260,7 +260,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			 */
 			if ( '' !== $linkmod_type ) {
 				// Is linkmod, output the required element opener.
-				$item_output .= self::linkmod_element_open( $linkmod_type, $attributes );
+				$item_output .= $this->linkmod_element_open( $linkmod_type, $attributes );
 			} else {
 				// With no link mod type set this must be a standard <a> tag.
 				$item_output .= '<a' . $attributes . '>';
@@ -294,7 +294,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 
 			// If the .sr-only class was set apply to the nav items text only.
 			if ( in_array( 'sr-only', $linkmod_classes, true ) ) {
-				$title         = self::wrap_for_screen_reader( $title );
+				$title         = $this->wrap_for_screen_reader( $title );
 				$keys_to_unset = array_keys( $linkmod_classes, 'sr-only', true );
 				foreach ( $keys_to_unset as $k ) {
 					unset( $linkmod_classes[ $k ] );
@@ -310,7 +310,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			 */
 			if ( '' !== $linkmod_type ) {
 				// Is linkmod, output the required closing element.
-				$item_output .= self::linkmod_element_close( $linkmod_type );
+				$item_output .= $this->linkmod_element_close( $linkmod_type );
 			} else {
 				// With no link mod type set this must be a standard <a> tag.
 				$item_output .= '</a>';


### PR DESCRIPTION
Non static methods should not be called statically.

#### Changes proposed in this Pull Request:

* Replaces `self::` with `$this->` when calling a non static method.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix non static method calls