### PR TITLE
Fix placement of the .active class for dropdown items & remove dropdown when item has no visible children

### DIFF
--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			}
 
 			// Whether the current item is active or the item is an ancestor of
-			// the current item.
+			// an active item.
 			$is_active = false;
 			if ( $item->current || $item->current_item_ancestor ) {
 				if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			}
 
 			// If the item has_children add atts to <a>.
-			if ( $this->has_children && 0 === $depth ) {
+			if ( $is_dropdown ) {
 				$atts['href']          = '#';
 				$atts['data-toggle']   = 'dropdown';
 				$atts['aria-expanded'] = 'false';

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -156,7 +156,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			$is_dropdown = false;
 			if ( $this->has_children && 1 !== $args->depth ) {
 				$is_dropdown = true;
-				if ( $depth >= $args->depth - 1 && $args->depth !== 0 ) {
+				if ( $depth >= $args->depth - 1 && 0 !== $args->depth ) {
 					$is_dropdown = false;
 				}
 			}
@@ -251,7 +251,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
 				if ( $is_dropdown_item ) {
-					$atts['class'] = 'dropdown-item';
+					$atts['class']  = 'dropdown-item';
 					$atts['class'] .= $is_active ? ' active' : '';
 				} else {
 					$atts['class'] = 'nav-link';

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -152,6 +152,30 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			// Join any icon classes plucked from $classes into a string.
 			$icon_class_string = join( ' ', $icon_classes );
 
+			// Whether the current item is a dropdown.
+			$is_dropdown = false;
+			if ( $this->has_children && 1 !== $args->depth ) {
+				$is_dropdown = true;
+				if ( $depth >= $args->depth - 1 && $args->depth !== 0 ) {
+					$is_dropdown = false;
+				}
+			}
+
+			// Whether the current item is a dropdown item.
+			$is_dropdown_item = false;
+			if ( ! ( $this->has_children && 0 === $depth ) && $depth > 0 ) {
+				$is_dropdown_item = true;
+			}
+
+			// Whether the current item is active or the item is an ancestor of
+			// the current item.
+			$is_active = false;
+			if ( $item->current || $item->current_item_ancestor ) {
+				if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {
+					$is_active = true;
+				}
+			}
+
 			/**
 			 * Filters the arguments for a single nav menu item.
 			 *
@@ -165,11 +189,12 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			 */
 			$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
 
-			// Add .dropdown or .active classes where they are needed.
-			if ( $this->has_children ) {
+			if ( $is_dropdown ) {
 				$classes[] = 'dropdown';
 			}
-			if ( in_array( 'current-menu-item', $classes, true ) || in_array( 'current-menu-parent', $classes, true ) ) {
+
+			if ( $is_active && ! $is_dropdown_item ) {
+				// For dropdown items the .active class is set on the a tag.
 				$classes[] = 'active';
 			}
 
@@ -226,6 +251,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
 				if ( $depth > 0 ) {
 					$atts['class'] = 'dropdown-item';
+					$atts['class'] .= $is_active ? ' active' : '';
 				} else {
 					$atts['class'] = 'nav-link';
 				}

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -248,8 +248,9 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 				}
 
 				$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
+
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
-				if ( $depth > 0 ) {
+				if ( $is_dropdown_item ) {
 					$atts['class'] = 'dropdown-item';
 					$atts['class'] .= $is_active ? ' active' : '';
 				} else {


### PR DESCRIPTION
Fixes #431 (misplaced `.active` class).
Fixes dropdown markup on items without children (reported in https://github.com/wp-bootstrap/wp-bootstrap-navwalker/issues/517#issuecomment-909436992).

#### Changes proposed in this Pull Request:

* Defines 3 new  boolean variables for better readability: `$is_dropdown`, `$is_dropdown_item`, `$is_active`. They indicate whether a menu item is a dropdown, a dropdown item and whether the menu item is active.
* Removes the `.active` class from the li-element and add it to the a-element if the item is a dropdown item. (https://getbootstrap.com/docs/4.6/components/dropdowns/#active)
* Removes the dropdown markup if a menu item has children but display is restricted by $args-depth.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Fix misplaced .active class
Remove dropdown markup on items without visible children