### PR TITLE
[WIP] Add Bootstrap 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,27 +146,20 @@ Bootstrap 5 uses namespaced data attributes. All `data` attributes now include `
 </button>
 ```
 
-The walker also adds a data attribute for dropdown toggles via the `start_el()` method. Paste this to your functions.php to make the walker use the infixed data attibute.
+To enable Bootstrap 5 support add a `bs_version` key to the array of arguments passed to the `wp_nav_menu()` function.
 
-```php
-add_filter( 'nav_menu_link_attributes', 'prefix_bs5_dropdown_data_attribute', 20, 3 );
-/**
- * Use namespaced data attribute for Bootstrap's dropdown toggles.
- *
- * @param array    $atts HTML attributes applied to the item's `<a>` element.
- * @param WP_Post  $item The current menu item.
- * @param stdClass $args An object of wp_nav_menu() arguments.
- * @return array
- */
-function prefix_bs5_dropdown_data_attribute( $atts, $item, $args ) {
-    if ( is_a( $args->walker, 'WP_Bootstrap_Navwalker' ) ) {
-        if ( array_key_exists( 'data-toggle', $atts ) ) {
-            unset( $atts['data-toggle'] );
-            $atts['data-bs-toggle'] = 'dropdown';
-        }
-    }
-    return $atts;
-}
+```diff
+wp_nav_menu( array(
+    'theme_location'  => 'primary',
+    'depth'           => 2, // 1 = no dropdowns, 2 = with dropdowns.
+    'container'       => 'div',
+    'container_class' => 'collapse navbar-collapse',
+    'container_id'    => 'bs-example-navbar-collapse-1',
+    'menu_class'      => 'navbar-nav mr-auto',
+    'fallback_cb'     => 'WP_Bootstrap_Navwalker::fallback',
+    'walker'          => new WP_Bootstrap_Navwalker(),
++    'bs_version'      => 5,
+) );
 ```
 
 ### Menu Caching

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -168,7 +168,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			}
 
 			// Whether the current item is active or the item is an ancestor of
-			// the current item.
+			// an active item.
 			$is_active = false;
 			if ( $item->current || $item->current_item_ancestor ) {
 				if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -90,12 +90,12 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
 
 		/*
-			* The `.dropdown-menu` container needs to have a labelledby
-			* attribute which points to it's trigger link.
-			*
-			* Form a string for the labelledby attribute from the the latest
-			* link with an id that was added to the $output.
-			*/
+		 * The `.dropdown-menu` container needs to have a labelledby
+		 * attribute which points to it's trigger link.
+		 *
+		 * Form a string for the labelledby attribute from the the latest
+		 * link with an id that was added to the $output.
+		 */
 		$labelledby = '';
 		// Find all links with an id in the output.
 		preg_match_all( '/(<a.*?id=\"|\')(.*?)\"|\'.*?>/im', $output, $matches );
@@ -140,28 +140,28 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
 
 		/*
-			* Updating the CSS classes of a menu item in the WordPress
-			* Customizer preview results in all classes defined in that
-			* particular input box to come in as one big class string.
-			*/
+		 * Updating the CSS classes of a menu item in the WordPress
+		 * Customizer preview results in all classes defined in that
+		 * particular input box to come in as one big class string.
+		 */
 		$split_on_spaces = function ( $class ) {
 			return preg_split( '/\s+/', $class );
 		};
 		$classes         = $this->flatten( array_map( $split_on_spaces, $classes ) );
 
 		/*
-			* Initialize some holder variables to store specially handled item
-			* wrappers and icons.
-			*/
+		 * Initialize some holder variables to store specially handled item
+		 * wrappers and icons.
+		 */
 		$linkmod_classes = array();
 		$icon_classes    = array();
 
 		/*
-			* Get an updated $classes array without linkmod or icon classes.
-			*
-			* NOTE: linkmod and icon class arrays are passed by reference and
-			* are maybe modified before being used later in this function.
-			*/
+		 * Get an updated $classes array without linkmod or icon classes.
+		 *
+		 * NOTE: linkmod and icon class arrays are passed by reference and
+		 * are maybe modified before being used later in this function.
+		 */
 		$classes = $this->separate_linkmods_and_icons_from_classes( $classes, $linkmod_classes, $icon_classes, $depth );
 
 		// Join any icon classes plucked from $classes into a string.
@@ -186,9 +186,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		}
 
 		/*
-			* Whether the current item is active or the item is an ancestor of
-			* an active item.
-			*/
+		 * Whether the current item is active or the item is an ancestor of
+		 * an active item.
+		 */
 		$is_active = false;
 		if ( $item->current || $item->current_item_ancestor ) {
 			if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {
@@ -309,9 +309,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		$item_output = isset( $args->before ) ? $args->before : '';
 
 		/*
-			* This is the start of the internal nav item. Depending on what
-			* kind of linkmod we have we may need different wrapper elements.
-			*/
+		 * This is the start of the internal nav item. Depending on what
+		 * kind of linkmod we have we may need different wrapper elements.
+		 */
 		if ( '' !== $linkmod_type ) {
 			// Is linkmod, output the required element opener.
 			$item_output .= $this->linkmod_element_open( $linkmod_type, $attributes );
@@ -321,10 +321,10 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		}
 
 		/*
-			* Initiate empty icon var, then if we have a string containing any
-			* icon classes form the icon markup with an <i> element. This is
-			* output inside of the item before the $title (the link text).
-			*/
+		 * Initiate empty icon var, then if we have a string containing any
+		 * icon classes form the icon markup with an <i> element. This is
+		 * output inside of the item before the $title (the link text).
+		 */
 		$icon_html = '';
 		if ( ! empty( $icon_class_string ) ) {
 			// Append an <i> with the icon classes to what is output before links.
@@ -359,9 +359,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		$item_output .= isset( $args->link_before ) ? $args->link_before . $icon_html . $title . $args->link_after : '';
 
 		/*
-			* This is the end of the internal nav item. We need to close the
-			* correct element depending on the type of link or link mod.
-			*/
+		 * This is the end of the internal nav item. We need to close the
+		 * correct element depending on the type of link or link mod.
+		 */
 		if ( '' !== $linkmod_type ) {
 			// Is linkmod, output the required closing element.
 			$item_output .= $this->linkmod_element_close( $linkmod_type );
@@ -475,18 +475,18 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		// Loop through $classes array to find linkmod or icon classes.
 		foreach ( $classes as $key => $class ) {
 			/*
-				* If any special classes are found, store the class in it's
-				* holder array and and unset the item from $classes.
-				*/
+			 * If any special classes are found, store the class in it's
+			 * holder array and and unset the item from $classes.
+			 */
 			if ( preg_match( '/^disabled|^sr-only/i', $class ) ) {
 				// Test for .disabled or .sr-only classes.
 				$linkmod_classes[] = $class;
 				unset( $classes[ $key ] );
 			} elseif ( preg_match( '/^dropdown-header|^dropdown-divider|^dropdown-item-text/i', $class ) && $depth > 0 ) {
 				/*
-					* Test for .dropdown-header or .dropdown-divider and a
-					* depth greater than 0 - IE inside a dropdown.
-					*/
+				 * Test for .dropdown-header or .dropdown-divider and a
+				 * depth greater than 0 - IE inside a dropdown.
+				 */
 				$linkmod_classes[] = $class;
 				unset( $classes[ $key ] );
 			} elseif ( preg_match( '/^fa-(\S*)?|^fa(s|r|l|b)?(\s?)?$/i', $class ) ) {
@@ -547,9 +547,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 			foreach ( $linkmod_classes as $link_class ) {
 				if ( ! empty( $link_class ) ) {
 					/*
-						* Update $atts with a space and the extra classname
-						* so long as it's not a sr-only class.
-						*/
+					 * Update $atts with a space and the extra classname
+					 * so long as it's not a sr-only class.
+					 */
 					if ( 'sr-only' !== $link_class ) {
 						$atts['class'] .= ' ' . esc_attr( $link_class );
 					}
@@ -599,9 +599,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 			$output .= '<span class="dropdown-item-text"' . $attributes . '>';
 		} elseif ( 'dropdown-header' === $linkmod_type ) {
 			/*
-				* For a header use a span with the .h6 class instead of a real
-				* header tag so that it doesn't confuse screen readers.
-				*/
+			 * For a header use a span with the .h6 class instead of a real
+			 * header tag so that it doesn't confuse screen readers.
+			 */
 			$output .= '<span class="dropdown-header h6"' . $attributes . '>';
 		} elseif ( 'dropdown-divider' === $linkmod_type ) {
 			// This is a divider.
@@ -622,9 +622,9 @@ class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
 		$output = '';
 		if ( 'dropdown-header' === $linkmod_type || 'dropdown-item-text' === $linkmod_type ) {
 			/*
-				* For a header use a span with the .h6 class instead of a real
-				* header tag so that it doesn't confuse screen readers.
-				*/
+			 * For a header use a span with the .h6 class instead of a real
+			 * header tag so that it doesn't confuse screen readers.
+			 */
 			$output .= '</span>';
 		} elseif ( 'dropdown-divider' === $linkmod_type ) {
 			// This is a divider.

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -18,648 +18,649 @@
  */
 
 // Check if Class Exists.
-if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
+if ( class_exists( 'WP_Bootstrap_Navwalker' ) ) {
+	return;
+}
+
+/**
+ * WP_Bootstrap_Navwalker class.
+ */
+class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
+
 	/**
-	 * WP_Bootstrap_Navwalker class.
+	 * Whether the items_wrap contains schema microdata or not.
+	 *
+	 * @since 4.2.0
+	 * @var boolean
 	 */
-	class WP_Bootstrap_Navwalker extends Walker_Nav_Menu {
-
-		/**
-		 * Whether the items_wrap contains schema microdata or not.
-		 *
-		 * @since 4.2.0
-		 * @var boolean
-		 */
-		private $has_schema = false;
-
-		/**
-		 * The default major Bootstrap version for which to create the markup.
-		 *
-		 * @var int
-		 */
-		private $bs_version = 4;
-
-		/**
-		 * Ensures the items_wrap argument contains microdata.
-		 *
-		 * @since 4.2.0
-		 */
-		public function __construct() {
-			if ( ! has_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) ) ) {
-				add_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) );
-			}
-		}
-
-		/**
-		 * Starts the list before the elements are added.
-		 *
-		 * @since WP 3.0.0
-		 *
-		 * @see Walker_Nav_Menu::start_lvl()
-		 *
-		 * @param string           $output Used to append additional content (passed by reference).
-		 * @param int              $depth  Depth of menu item. Used for padding.
-		 * @param WP_Nav_Menu_Args $args   An object of `wp_nav_menu()` arguments.
-		 */
-		public function start_lvl( &$output, $depth = 0, $args = null ) {
-			if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
-				$t = '';
-				$n = '';
-			} else {
-				$t = "\t";
-				$n = "\n";
-			}
-			$indent = str_repeat( $t, $depth );
-
-			// Default class to add to the start of the list (usually ul tag).
-			$classes = array( 'dropdown-menu' );
-
-			/**
-			 * Filters the CSS class(es) applied to a menu list element.
-			 *
-			 * @since WP 4.8.0
-			 *
-			 * @param array    $classes The CSS classes that are applied to the menu `<ul>` element.
-			 * @param stdClass $args    An object of `wp_nav_menu()` arguments.
-			 * @param int      $depth   Depth of menu item. Used for padding.
-			 */
-			$class_names = join( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
-			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
-
-			/*
-			 * The `.dropdown-menu` container needs to have a labelledby
-			 * attribute which points to it's trigger link.
-			 *
-			 * Form a string for the labelledby attribute from the the latest
-			 * link with an id that was added to the $output.
-			 */
-			$labelledby = '';
-			// Find all links with an id in the output.
-			preg_match_all( '/(<a.*?id=\"|\')(.*?)\"|\'.*?>/im', $output, $matches );
-			// With pointer at end of array check if we got an ID match.
-			if ( end( $matches[2] ) ) {
-				// Build a string to use as aria-labelledby.
-				$labelledby = 'aria-labelledby="' . esc_attr( end( $matches[2] ) ) . '"';
-			}
-			$output .= "{$n}{$indent}<ul$class_names $labelledby>{$n}";
-		}
-
-		/**
-		 * Starts the element output.
-		 *
-		 * @since WP 3.0.0
-		 * @since WP 4.4.0 The {@see 'nav_menu_item_args'} filter was added.
-		 *
-		 * @see Walker_Nav_Menu::start_el()
-		 *
-		 * @param string           $output Used to append additional content (passed by reference).
-		 * @param WP_Nav_Menu_Item $item   Menu item data object.
-		 * @param int              $depth  Depth of menu item. Used for padding.
-		 * @param WP_Nav_Menu_Args $args   An object of `wp_nav_menu()` arguments.
-		 * @param int              $id     Current item ID.
-		 */
-		public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
-			if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
-				$t = '';
-				$n = '';
-			} else {
-				$t = "\t";
-				$n = "\n";
-			}
-			$indent = ( $depth ) ? str_repeat( $t, $depth ) : '';
-
-			if ( false !== strpos( $args->items_wrap, 'itemscope' ) && false === $this->has_schema ) {
-				$this->has_schema  = true;
-				$args->link_before = '<span itemprop="name">' . $args->link_before;
-				$args->link_after .= '</span>';
-			}
-
-			$classes = empty( $item->classes ) ? array() : (array) $item->classes;
-
-			/*
-			 * Updating the CSS classes of a menu item in the WordPress
-			 * Customizer preview results in all classes defined in that
-			 * particular input box to come in as one big class string.
-			 */
-			$split_on_spaces = function ( $class ) {
-				return preg_split( '/\s+/', $class );
-			};
-			$classes         = $this->flatten( array_map( $split_on_spaces, $classes ) );
-
-			/*
-			 * Initialize some holder variables to store specially handled item
-			 * wrappers and icons.
-			 */
-			$linkmod_classes = array();
-			$icon_classes    = array();
-
-			/*
-			 * Get an updated $classes array without linkmod or icon classes.
-			 *
-			 * NOTE: linkmod and icon class arrays are passed by reference and
-			 * are maybe modified before being used later in this function.
-			 */
-			$classes = $this->separate_linkmods_and_icons_from_classes( $classes, $linkmod_classes, $icon_classes, $depth );
-
-			// Join any icon classes plucked from $classes into a string.
-			$icon_class_string = join( ' ', $icon_classes );
-
-			// Bootstrap version to create the markup for.
-			$bs_version = $this->get_bs_version( $args );
-
-			// Whether the current item is a dropdown.
-			$is_dropdown = false;
-			if ( $this->has_children && 1 !== $args->depth ) {
-				$is_dropdown = true;
-				if ( $depth >= $args->depth - 1 && 0 !== $args->depth ) {
-					$is_dropdown = false;
-				}
-			}
-
-			// Whether the current item is a dropdown item.
-			$is_dropdown_item = false;
-			if ( ! ( $this->has_children && 0 === $depth ) && $depth > 0 ) {
-				$is_dropdown_item = true;
-			}
-
-			/*
-			 * Whether the current item is active or the item is an ancestor of
-			 * an active item.
-			 */
-			$is_active = false;
-			if ( $item->current || $item->current_item_ancestor ) {
-				if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {
-					$is_active = true;
-				}
-			}
-
-			/**
-			 * Filters the arguments for a single nav menu item.
-			 *
-			 * @since WP 4.4.0
-			 *
-			 * @param WP_Nav_Menu_Args $args  An object of `wp_nav_menu()` arguments.
-			 * @param WP_Nav_Menu_Item $item  Menu item data object.
-			 * @param int              $depth Depth of menu item. Used for padding.
-			 *
-			 * @var WP_Nav_Menu_Args
-			 */
-			$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
-
-			if ( $is_dropdown ) {
-				$classes[] = 'dropdown';
-			}
-
-			if ( $is_active && ! $is_dropdown_item && 5 !== $bs_version ) {
-				// For dropdown items the .active class is set on the a tag.
-				$classes[] = 'active';
-			}
-
-			// Add some additional default classes to the item.
-			$classes[] = 'menu-item-' . $item->ID;
-			$classes[] = 'nav-item';
-
-			// Allow filtering the classes.
-			$classes = apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth );
-
-			// Form a string of classes in format: class="class_names".
-			$class_names = join( ' ', $classes );
-			$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
-
-			/**
-			 * Filters the ID applied to a menu item's list item element.
-			 *
-			 * @since WP 3.0.1
-			 * @since WP 4.1.0 The `$depth` parameter was added.
-			 *
-			 * @param string           $menu_id The ID that is applied to the menu item's `<li>` element.
-			 * @param WP_Nav_Menu_Item $item    The current menu item.
-			 * @param WP_Nav_Menu_Args $args    An object of `wp_nav_menu()` arguments.
-			 * @param int              $depth   Depth of menu item. Used for padding.
-			 */
-			$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
-			$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
-
-			$output .= $indent . '<li ' . $id . $class_names . '>';
-
-			// Initialize array for holding the $atts for the link item.
-			$atts           = array();
-			$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
-			$atts['target'] = ! empty( $item->target ) ? $item->target : '';
-			if ( '_blank' === $item->target && empty( $item->xfn ) ) {
-				$atts['rel'] = 'noopener noreferrer';
-			} else {
-				$atts['rel'] = ! empty( $item->xfn ) ? $item->xfn : '';
-			}
-
-			// If the item has_children add atts to <a>.
-			if ( $is_dropdown ) {
-				$infix = '';
-				if ( 5 === $this->get_bs_version( $args ) ) {
-					$infix = '-bs';
-				}
-
-				$atts['href']                = '#';
-				$atts[ "data$infix-toggle" ] = 'dropdown';
-				$atts['aria-expanded']       = 'false';
-				$atts['class']               = 'dropdown-toggle nav-link';
-				$atts['id']                  = 'menu-item-dropdown-' . $item->ID;
-
-				$atts['class'] .= ( $is_active && 5 === $bs_version ) ? ' active' : '';
-			} else {
-				if ( true === $this->has_schema ) {
-					$atts['itemprop'] = 'url';
-				}
-
-				$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
-
-				// For items in dropdowns use .dropdown-item instead of .nav-link.
-				if ( $is_dropdown_item ) {
-					$atts['class']  = 'dropdown-item';
-					$atts['class'] .= $is_active ? ' active' : '';
-				} else {
-					$atts['class'] = 'nav-link';
-				}
-			}
-
-			$atts['aria-current'] = $item->current ? 'page' : '';
-
-			// Update atts of this item based on any custom linkmod classes.
-			$atts = $this->update_atts_for_linkmod_type( $atts, $linkmod_classes );
-
-			// Allow filtering of the $atts array before using it.
-			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
-
-			// Build a string of html containing all the atts for the item.
-			$attributes = '';
-			foreach ( $atts as $attr => $value ) {
-				if ( ! empty( $value ) ) {
-					$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
-					$attributes .= ' ' . $attr . '="' . $value . '"';
-				}
-			}
-
-			// Set a typeflag to easily test if this is a linkmod or not.
-			$linkmod_type = $this->get_linkmod_type( $linkmod_classes );
-
-			// START appending the internal item contents to the output.
-			$item_output = isset( $args->before ) ? $args->before : '';
-
-			/*
-			 * This is the start of the internal nav item. Depending on what
-			 * kind of linkmod we have we may need different wrapper elements.
-			 */
-			if ( '' !== $linkmod_type ) {
-				// Is linkmod, output the required element opener.
-				$item_output .= $this->linkmod_element_open( $linkmod_type, $attributes );
-			} else {
-				// With no link mod type set this must be a standard <a> tag.
-				$item_output .= '<a' . $attributes . '>';
-			}
-
-			/*
-			 * Initiate empty icon var, then if we have a string containing any
-			 * icon classes form the icon markup with an <i> element. This is
-			 * output inside of the item before the $title (the link text).
-			 */
-			$icon_html = '';
-			if ( ! empty( $icon_class_string ) ) {
-				// Append an <i> with the icon classes to what is output before links.
-				$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '" aria-hidden="true"></i> ';
-			}
-
-			/** This filter is documented in wp-includes/post-template.php */
-			$title = apply_filters( 'the_title', $item->title, $item->ID );
-
-			/**
-			 * Filters a menu item's title.
-			 *
-			 * @since WP 4.4.0
-			 *
-			 * @param string           $title The menu item's title.
-			 * @param WP_Nav_Menu_Item $item  The current menu item.
-			 * @param WP_Nav_Menu_Args $args  An object of `wp_nav_menu()` arguments.
-			 * @param int              $depth Depth of menu item. Used for padding.
-			 */
-			$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
-
-			// If the .sr-only class was set apply to the nav items text only.
-			if ( in_array( 'sr-only', $linkmod_classes, true ) ) {
-				$title         = $this->wrap_for_screen_reader( $title );
-				$keys_to_unset = array_keys( $linkmod_classes, 'sr-only', true );
-				foreach ( $keys_to_unset as $k ) {
-					unset( $linkmod_classes[ $k ] );
-				}
-			}
-
-			// Put the item contents into $output.
-			$item_output .= isset( $args->link_before ) ? $args->link_before . $icon_html . $title . $args->link_after : '';
-
-			/*
-			 * This is the end of the internal nav item. We need to close the
-			 * correct element depending on the type of link or link mod.
-			 */
-			if ( '' !== $linkmod_type ) {
-				// Is linkmod, output the required closing element.
-				$item_output .= $this->linkmod_element_close( $linkmod_type );
-			} else {
-				// With no link mod type set this must be a standard <a> tag.
-				$item_output .= '</a>';
-			}
-
-			$item_output .= isset( $args->after ) ? $args->after : '';
-
-			// END appending the internal item contents to the output.
-			$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
-		}
-
-		/**
-		 * Menu fallback.
-		 *
-		 * If this function is assigned to the wp_nav_menu's fallback_cb variable
-		 * and a menu has not been assigned to the theme location in the WordPress
-		 * menu manager the function will display nothing to a non-logged in user,
-		 * and will add a link to the WordPress menu manager if logged in as an admin.
-		 *
-		 * @param array $args Arguments passed from the `wp_nav_menu()` function.
-		 * @return string|void String when echo is false.
-		 */
-		public static function fallback( $args ) {
-			if ( ! current_user_can( 'edit_theme_options' ) ) {
-				return;
-			}
-
-			// Initialize var to store fallback html.
-			$fallback_output = '';
-
-			// Menu container opening tag.
-			$show_container = false;
-			if ( $args['container'] ) {
-				/**
-				 * Filters the list of HTML tags that are valid for use as menu containers.
-				 *
-				 * @since WP 3.0.0
-				 *
-				 * @param array $tags The acceptable HTML tags for use as menu containers.
-				 *                    Default is array containing 'div' and 'nav'.
-				 */
-				$allowed_tags = apply_filters( 'wp_nav_menu_container_allowedtags', array( 'div', 'nav' ) );
-				if ( is_string( $args['container'] ) && in_array( $args['container'], $allowed_tags, true ) ) {
-					$show_container   = true;
-					$class            = $args['container_class'] ? ' class="menu-fallback-container ' . esc_attr( $args['container_class'] ) . '"' : ' class="menu-fallback-container"';
-					$id               = $args['container_id'] ? ' id="' . esc_attr( $args['container_id'] ) . '"' : '';
-					$fallback_output .= '<' . $args['container'] . $id . $class . '>';
-				}
-			}
-
-			// The fallback menu.
-			$class            = $args['menu_class'] ? ' class="menu-fallback-menu ' . esc_attr( $args['menu_class'] ) . '"' : ' class="menu-fallback-menu"';
-			$id               = $args['menu_id'] ? ' id="' . esc_attr( $args['menu_id'] ) . '"' : '';
-			$fallback_output .= '<ul' . $id . $class . '>';
-			$fallback_output .= '<li class="nav-item"><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" class="nav-link" title="' . esc_attr__( 'Add a menu', 'wp-bootstrap-navwalker' ) . '">' . esc_html__( 'Add a menu', 'wp-bootstrap-navwalker' ) . '</a></li>';
-			$fallback_output .= '</ul>';
-
-			// Menu container closing tag.
-			if ( $show_container ) {
-				$fallback_output .= '</' . $args['container'] . '>';
-			}
-
-			// If $args has 'echo' key and it's true echo, otherwise return.
-			if ( array_key_exists( 'echo', $args ) && $args['echo'] ) {
-				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				echo $fallback_output;
-			} else {
-				return $fallback_output;
-			}
-		}
-
-		/**
-		 * Filter to ensure the items_wrap argument contains microdata.
-		 *
-		 * @since 4.2.0
-		 *
-		 * @param  array $args The nav instance arguments.
-		 * @return array $args The altered nav instance arguments.
-		 */
-		public function add_schema_to_navbar_ul( $args ) {
-			if ( isset( $args['items_wrap'] ) ) {
-				$wrap = $args['items_wrap'];
-				if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
-					$args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', ' itemscope itemtype="http://www.schema.org/SiteNavigationElement"$0', $wrap );
-				}
-			}
-			return $args;
-		}
-
-		/**
-		 * Finds any custom linkmod or icon classes and store in their holder
-		 * arrays then remove them from the main classes array.
-		 *
-		 * Supported linkmods: .disabled, .dropdown-header, .dropdown-divider, .sr-only
-		 * Supported iconsets: Font Awesome 4/5, Glypicons
-		 *
-		 * NOTE: This accepts the linkmod and icon arrays by reference.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param array   $classes         An array of classes currently assigned to the item.
-		 * @param array   $linkmod_classes An array to hold linkmod classes.
-		 * @param array   $icon_classes    An array to hold icon classes.
-		 * @param integer $depth           An integer holding current depth level.
-		 * @return array  $classes A maybe modified array of classnames.
-		 */
-		private function separate_linkmods_and_icons_from_classes( $classes, &$linkmod_classes, &$icon_classes, $depth ) {
-			// Loop through $classes array to find linkmod or icon classes.
-			foreach ( $classes as $key => $class ) {
-				/*
-				 * If any special classes are found, store the class in it's
-				 * holder array and and unset the item from $classes.
-				 */
-				if ( preg_match( '/^disabled|^sr-only/i', $class ) ) {
-					// Test for .disabled or .sr-only classes.
-					$linkmod_classes[] = $class;
-					unset( $classes[ $key ] );
-				} elseif ( preg_match( '/^dropdown-header|^dropdown-divider|^dropdown-item-text/i', $class ) && $depth > 0 ) {
-					/*
-					 * Test for .dropdown-header or .dropdown-divider and a
-					 * depth greater than 0 - IE inside a dropdown.
-					 */
-					$linkmod_classes[] = $class;
-					unset( $classes[ $key ] );
-				} elseif ( preg_match( '/^fa-(\S*)?|^fa(s|r|l|b)?(\s?)?$/i', $class ) ) {
-					// Font Awesome.
-					$icon_classes[] = $class;
-					unset( $classes[ $key ] );
-				} elseif ( preg_match( '/^glyphicon-(\S*)?|^glyphicon(\s?)$/i', $class ) ) {
-					// Glyphicons.
-					$icon_classes[] = $class;
-					unset( $classes[ $key ] );
-				}
-			}
-
-			return $classes;
-		}
-
-		/**
-		 * Returns a string containing a linkmod type and updates the $atts
-		 * array accordingly depending on the decided.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param array $linkmod_classes Array of any link modifier classes.
-		 * @return string Empty for default, a linkmod type string otherwise.
-		 */
-		private function get_linkmod_type( $linkmod_classes = array() ) {
-			$linkmod_type = '';
-			// Loop through array of linkmod classes to handle their $atts.
-			if ( ! empty( $linkmod_classes ) ) {
-				foreach ( $linkmod_classes as $link_class ) {
-					if ( ! empty( $link_class ) ) {
-
-						// Check for special class types and set a flag for them.
-						if ( 'dropdown-header' === $link_class ) {
-							$linkmod_type = 'dropdown-header';
-						} elseif ( 'dropdown-divider' === $link_class ) {
-							$linkmod_type = 'dropdown-divider';
-						} elseif ( 'dropdown-item-text' === $link_class ) {
-							$linkmod_type = 'dropdown-item-text';
-						}
-					}
-				}
-			}
-			return $linkmod_type;
-		}
-
-		/**
-		 * Updates the attributes of a nav item depending on the limkmod classes.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param array $atts            Array of atts for the current link in nav item.
-		 * @param array $linkmod_classes An array of classes that modify link or nav item behaviors or displays.
-		 * @return array Maybe updated array of attributes for item.
-		 */
-		private function update_atts_for_linkmod_type( $atts = array(), $linkmod_classes = array() ) {
-			if ( ! empty( $linkmod_classes ) ) {
-				foreach ( $linkmod_classes as $link_class ) {
-					if ( ! empty( $link_class ) ) {
-						/*
-						 * Update $atts with a space and the extra classname
-						 * so long as it's not a sr-only class.
-						 */
-						if ( 'sr-only' !== $link_class ) {
-							$atts['class'] .= ' ' . esc_attr( $link_class );
-						}
-						// Check for special class types we need additional handling for.
-						if ( 'disabled' === $link_class ) {
-							// Convert link to '#' and unset open targets.
-							$atts['href'] = '#';
-							unset( $atts['target'] );
-						} elseif ( 'dropdown-header' === $link_class || 'dropdown-divider' === $link_class || 'dropdown-item-text' === $link_class ) {
-							// Store a type flag and unset href and target.
-							unset( $atts['href'] );
-							unset( $atts['target'] );
-						}
-					}
-				}
-			}
-			return $atts;
-		}
-
-		/**
-		 * Wraps the passed text in a screen reader only class.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param string $text The string of text to be wrapped in a screen reader class.
-		 * @return string The string wrapped in a span with the class.
-		 */
-		private function wrap_for_screen_reader( $text = '' ) {
-			if ( $text ) {
-				$text = '<span class="sr-only">' . $text . '</span>';
-			}
-			return $text;
-		}
-
-		/**
-		 * Returns the correct opening element and attributes for a linkmod.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param string $linkmod_type A string containing a linkmod type flag.
-		 * @param string $attributes   A string of attributes to add to the element.
-		 * @return string A string with the opening tag for the element with attribibutes added.
-		 */
-		private function linkmod_element_open( $linkmod_type, $attributes = '' ) {
-			$output = '';
-			if ( 'dropdown-item-text' === $linkmod_type ) {
-				$output .= '<span class="dropdown-item-text"' . $attributes . '>';
-			} elseif ( 'dropdown-header' === $linkmod_type ) {
-				/*
-				 * For a header use a span with the .h6 class instead of a real
-				 * header tag so that it doesn't confuse screen readers.
-				 */
-				$output .= '<span class="dropdown-header h6"' . $attributes . '>';
-			} elseif ( 'dropdown-divider' === $linkmod_type ) {
-				// This is a divider.
-				$output .= '<div class="dropdown-divider"' . $attributes . '>';
-			}
-			return $output;
-		}
-
-		/**
-		 * Returns the correct closing tag for the linkmod element.
-		 *
-		 * @since 4.0.0
-		 *
-		 * @param string $linkmod_type A string containing a special linkmod type.
-		 * @return string A string with the closing tag for this linkmod type.
-		 */
-		private function linkmod_element_close( $linkmod_type ) {
-			$output = '';
-			if ( 'dropdown-header' === $linkmod_type || 'dropdown-item-text' === $linkmod_type ) {
-				/*
-				 * For a header use a span with the .h6 class instead of a real
-				 * header tag so that it doesn't confuse screen readers.
-				 */
-				$output .= '</span>';
-			} elseif ( 'dropdown-divider' === $linkmod_type ) {
-				// This is a divider.
-				$output .= '</div>';
-			}
-			return $output;
-		}
-
-		/**
-		 * Flattens a multidimensional array to a simple array.
-		 *
-		 * @param array $array A multidimensional array.
-		 * @return array A simple array.
-		 */
-		public function flatten( $array ) {
-			$result = array();
-			foreach ( $array as $element ) {
-				if ( is_array( $element ) ) {
-					array_push( $result, ...$this->flatten( $element ) );
-				} else {
-					$result[] = $element;
-				}
-			}
-			return $result;
-		}
-
-		/**
-		 * Retrieves the Bootstrap version to use.
-		 *
-		 * @param WP_Nav_Menu_Args $args An object of `wp_nav_menu()` arguments.
-		 * @return int Major Bootstrap version
-		 */
-		private function get_bs_version( $args ) {
-			if ( property_exists( $args, 'bs_version' ) && 5 === (int) $args->bs_version ) {
-				return (int) $args->bs_version;
-			}
-			return $this->bs_version;
+	private $has_schema = false;
+
+	/**
+	 * The default major Bootstrap version for which to create the markup.
+	 *
+	 * @var int
+	 */
+	private $bs_version = 4;
+
+	/**
+	 * Ensures the items_wrap argument contains microdata.
+	 *
+	 * @since 4.2.0
+	 */
+	public function __construct() {
+		if ( ! has_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) ) ) {
+			add_filter( 'wp_nav_menu_args', array( $this, 'add_schema_to_navbar_ul' ) );
 		}
 	}
 
-endif;
+	/**
+	 * Starts the list before the elements are added.
+	 *
+	 * @since WP 3.0.0
+	 *
+	 * @see Walker_Nav_Menu::start_lvl()
+	 *
+	 * @param string           $output Used to append additional content (passed by reference).
+	 * @param int              $depth  Depth of menu item. Used for padding.
+	 * @param WP_Nav_Menu_Args $args   An object of `wp_nav_menu()` arguments.
+	 */
+	public function start_lvl( &$output, $depth = 0, $args = null ) {
+		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
+			$t = '';
+			$n = '';
+		} else {
+			$t = "\t";
+			$n = "\n";
+		}
+		$indent = str_repeat( $t, $depth );
+
+		// Default class to add to the start of the list (usually ul tag).
+		$classes = array( 'dropdown-menu' );
+
+		/**
+		 * Filters the CSS class(es) applied to a menu list element.
+		 *
+		 * @since WP 4.8.0
+		 *
+		 * @param array    $classes The CSS classes that are applied to the menu `<ul>` element.
+		 * @param stdClass $args    An object of `wp_nav_menu()` arguments.
+		 * @param int      $depth   Depth of menu item. Used for padding.
+		 */
+		$class_names = join( ' ', apply_filters( 'nav_menu_submenu_css_class', $classes, $args, $depth ) );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+		/*
+			* The `.dropdown-menu` container needs to have a labelledby
+			* attribute which points to it's trigger link.
+			*
+			* Form a string for the labelledby attribute from the the latest
+			* link with an id that was added to the $output.
+			*/
+		$labelledby = '';
+		// Find all links with an id in the output.
+		preg_match_all( '/(<a.*?id=\"|\')(.*?)\"|\'.*?>/im', $output, $matches );
+		// With pointer at end of array check if we got an ID match.
+		if ( end( $matches[2] ) ) {
+			// Build a string to use as aria-labelledby.
+			$labelledby = 'aria-labelledby="' . esc_attr( end( $matches[2] ) ) . '"';
+		}
+		$output .= "{$n}{$indent}<ul$class_names $labelledby>{$n}";
+	}
+
+	/**
+	 * Starts the element output.
+	 *
+	 * @since WP 3.0.0
+	 * @since WP 4.4.0 The {@see 'nav_menu_item_args'} filter was added.
+	 *
+	 * @see Walker_Nav_Menu::start_el()
+	 *
+	 * @param string           $output Used to append additional content (passed by reference).
+	 * @param WP_Nav_Menu_Item $item   Menu item data object.
+	 * @param int              $depth  Depth of menu item. Used for padding.
+	 * @param WP_Nav_Menu_Args $args   An object of `wp_nav_menu()` arguments.
+	 * @param int              $id     Current item ID.
+	 */
+	public function start_el( &$output, $item, $depth = 0, $args = null, $id = 0 ) {
+		if ( isset( $args->item_spacing ) && 'discard' === $args->item_spacing ) {
+			$t = '';
+			$n = '';
+		} else {
+			$t = "\t";
+			$n = "\n";
+		}
+		$indent = ( $depth ) ? str_repeat( $t, $depth ) : '';
+
+		if ( false !== strpos( $args->items_wrap, 'itemscope' ) && false === $this->has_schema ) {
+			$this->has_schema  = true;
+			$args->link_before = '<span itemprop="name">' . $args->link_before;
+			$args->link_after .= '</span>';
+		}
+
+		$classes = empty( $item->classes ) ? array() : (array) $item->classes;
+
+		/*
+			* Updating the CSS classes of a menu item in the WordPress
+			* Customizer preview results in all classes defined in that
+			* particular input box to come in as one big class string.
+			*/
+		$split_on_spaces = function ( $class ) {
+			return preg_split( '/\s+/', $class );
+		};
+		$classes         = $this->flatten( array_map( $split_on_spaces, $classes ) );
+
+		/*
+			* Initialize some holder variables to store specially handled item
+			* wrappers and icons.
+			*/
+		$linkmod_classes = array();
+		$icon_classes    = array();
+
+		/*
+			* Get an updated $classes array without linkmod or icon classes.
+			*
+			* NOTE: linkmod and icon class arrays are passed by reference and
+			* are maybe modified before being used later in this function.
+			*/
+		$classes = $this->separate_linkmods_and_icons_from_classes( $classes, $linkmod_classes, $icon_classes, $depth );
+
+		// Join any icon classes plucked from $classes into a string.
+		$icon_class_string = join( ' ', $icon_classes );
+
+		// Bootstrap version to create the markup for.
+		$bs_version = $this->get_bs_version( $args );
+
+		// Whether the current item is a dropdown.
+		$is_dropdown = false;
+		if ( $this->has_children && 1 !== $args->depth ) {
+			$is_dropdown = true;
+			if ( $depth >= $args->depth - 1 && 0 !== $args->depth ) {
+				$is_dropdown = false;
+			}
+		}
+
+		// Whether the current item is a dropdown item.
+		$is_dropdown_item = false;
+		if ( ! ( $this->has_children && 0 === $depth ) && $depth > 0 ) {
+			$is_dropdown_item = true;
+		}
+
+		/*
+			* Whether the current item is active or the item is an ancestor of
+			* an active item.
+			*/
+		$is_active = false;
+		if ( $item->current || $item->current_item_ancestor ) {
+			if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {
+				$is_active = true;
+			}
+		}
+
+		/**
+		 * Filters the arguments for a single nav menu item.
+		 *
+		 * @since WP 4.4.0
+		 *
+		 * @param WP_Nav_Menu_Args $args  An object of `wp_nav_menu()` arguments.
+		 * @param WP_Nav_Menu_Item $item  Menu item data object.
+		 * @param int              $depth Depth of menu item. Used for padding.
+		 *
+		 * @var WP_Nav_Menu_Args
+		 */
+		$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
+
+		if ( $is_dropdown ) {
+			$classes[] = 'dropdown';
+		}
+
+		if ( $is_active && ! $is_dropdown_item && 5 !== $bs_version ) {
+			// For dropdown items the .active class is set on the a tag.
+			$classes[] = 'active';
+		}
+
+		// Add some additional default classes to the item.
+		$classes[] = 'menu-item-' . $item->ID;
+		$classes[] = 'nav-item';
+
+		// Allow filtering the classes.
+		$classes = apply_filters( 'nav_menu_css_class', array_filter( $classes ), $item, $args, $depth );
+
+		// Form a string of classes in format: class="class_names".
+		$class_names = join( ' ', $classes );
+		$class_names = $class_names ? ' class="' . esc_attr( $class_names ) . '"' : '';
+
+		/**
+		 * Filters the ID applied to a menu item's list item element.
+		 *
+		 * @since WP 3.0.1
+		 * @since WP 4.1.0 The `$depth` parameter was added.
+		 *
+		 * @param string           $menu_id The ID that is applied to the menu item's `<li>` element.
+		 * @param WP_Nav_Menu_Item $item    The current menu item.
+		 * @param WP_Nav_Menu_Args $args    An object of `wp_nav_menu()` arguments.
+		 * @param int              $depth   Depth of menu item. Used for padding.
+		 */
+		$id = apply_filters( 'nav_menu_item_id', 'menu-item-' . $item->ID, $item, $args, $depth );
+		$id = $id ? ' id="' . esc_attr( $id ) . '"' : '';
+
+		$output .= $indent . '<li ' . $id . $class_names . '>';
+
+		// Initialize array for holding the $atts for the link item.
+		$atts           = array();
+		$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : '';
+		$atts['target'] = ! empty( $item->target ) ? $item->target : '';
+		if ( '_blank' === $item->target && empty( $item->xfn ) ) {
+			$atts['rel'] = 'noopener noreferrer';
+		} else {
+			$atts['rel'] = ! empty( $item->xfn ) ? $item->xfn : '';
+		}
+
+		// If the item has_children add atts to <a>.
+		if ( $is_dropdown ) {
+			$infix = '';
+			if ( 5 === $this->get_bs_version( $args ) ) {
+				$infix = '-bs';
+			}
+
+			$atts['href']                = '#';
+			$atts[ "data$infix-toggle" ] = 'dropdown';
+			$atts['aria-expanded']       = 'false';
+			$atts['class']               = 'dropdown-toggle nav-link';
+			$atts['id']                  = 'menu-item-dropdown-' . $item->ID;
+
+			$atts['class'] .= ( $is_active && 5 === $bs_version ) ? ' active' : '';
+		} else {
+			if ( true === $this->has_schema ) {
+				$atts['itemprop'] = 'url';
+			}
+
+			$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
+
+			// For items in dropdowns use .dropdown-item instead of .nav-link.
+			if ( $is_dropdown_item ) {
+				$atts['class']  = 'dropdown-item';
+				$atts['class'] .= $is_active ? ' active' : '';
+			} else {
+				$atts['class'] = 'nav-link';
+			}
+		}
+
+		$atts['aria-current'] = $item->current ? 'page' : '';
+
+		// Update atts of this item based on any custom linkmod classes.
+		$atts = $this->update_atts_for_linkmod_type( $atts, $linkmod_classes );
+
+		// Allow filtering of the $atts array before using it.
+		$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args, $depth );
+
+		// Build a string of html containing all the atts for the item.
+		$attributes = '';
+		foreach ( $atts as $attr => $value ) {
+			if ( ! empty( $value ) ) {
+				$value       = ( 'href' === $attr ) ? esc_url( $value ) : esc_attr( $value );
+				$attributes .= ' ' . $attr . '="' . $value . '"';
+			}
+		}
+
+		// Set a typeflag to easily test if this is a linkmod or not.
+		$linkmod_type = $this->get_linkmod_type( $linkmod_classes );
+
+		// START appending the internal item contents to the output.
+		$item_output = isset( $args->before ) ? $args->before : '';
+
+		/*
+			* This is the start of the internal nav item. Depending on what
+			* kind of linkmod we have we may need different wrapper elements.
+			*/
+		if ( '' !== $linkmod_type ) {
+			// Is linkmod, output the required element opener.
+			$item_output .= $this->linkmod_element_open( $linkmod_type, $attributes );
+		} else {
+			// With no link mod type set this must be a standard <a> tag.
+			$item_output .= '<a' . $attributes . '>';
+		}
+
+		/*
+			* Initiate empty icon var, then if we have a string containing any
+			* icon classes form the icon markup with an <i> element. This is
+			* output inside of the item before the $title (the link text).
+			*/
+		$icon_html = '';
+		if ( ! empty( $icon_class_string ) ) {
+			// Append an <i> with the icon classes to what is output before links.
+			$icon_html = '<i class="' . esc_attr( $icon_class_string ) . '" aria-hidden="true"></i> ';
+		}
+
+		/** This filter is documented in wp-includes/post-template.php */
+		$title = apply_filters( 'the_title', $item->title, $item->ID );
+
+		/**
+		 * Filters a menu item's title.
+		 *
+		 * @since WP 4.4.0
+		 *
+		 * @param string           $title The menu item's title.
+		 * @param WP_Nav_Menu_Item $item  The current menu item.
+		 * @param WP_Nav_Menu_Args $args  An object of `wp_nav_menu()` arguments.
+		 * @param int              $depth Depth of menu item. Used for padding.
+		 */
+		$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
+
+		// If the .sr-only class was set apply to the nav items text only.
+		if ( in_array( 'sr-only', $linkmod_classes, true ) ) {
+			$title         = $this->wrap_for_screen_reader( $title );
+			$keys_to_unset = array_keys( $linkmod_classes, 'sr-only', true );
+			foreach ( $keys_to_unset as $k ) {
+				unset( $linkmod_classes[ $k ] );
+			}
+		}
+
+		// Put the item contents into $output.
+		$item_output .= isset( $args->link_before ) ? $args->link_before . $icon_html . $title . $args->link_after : '';
+
+		/*
+			* This is the end of the internal nav item. We need to close the
+			* correct element depending on the type of link or link mod.
+			*/
+		if ( '' !== $linkmod_type ) {
+			// Is linkmod, output the required closing element.
+			$item_output .= $this->linkmod_element_close( $linkmod_type );
+		} else {
+			// With no link mod type set this must be a standard <a> tag.
+			$item_output .= '</a>';
+		}
+
+		$item_output .= isset( $args->after ) ? $args->after : '';
+
+		// END appending the internal item contents to the output.
+		$output .= apply_filters( 'walker_nav_menu_start_el', $item_output, $item, $depth, $args );
+	}
+
+	/**
+	 * Menu fallback.
+	 *
+	 * If this function is assigned to the wp_nav_menu's fallback_cb variable
+	 * and a menu has not been assigned to the theme location in the WordPress
+	 * menu manager the function will display nothing to a non-logged in user,
+	 * and will add a link to the WordPress menu manager if logged in as an admin.
+	 *
+	 * @param array $args Arguments passed from the `wp_nav_menu()` function.
+	 * @return string|void String when echo is false.
+	 */
+	public static function fallback( $args ) {
+		if ( ! current_user_can( 'edit_theme_options' ) ) {
+			return;
+		}
+
+		// Initialize var to store fallback html.
+		$fallback_output = '';
+
+		// Menu container opening tag.
+		$show_container = false;
+		if ( $args['container'] ) {
+			/**
+			 * Filters the list of HTML tags that are valid for use as menu containers.
+			 *
+			 * @since WP 3.0.0
+			 *
+			 * @param array $tags The acceptable HTML tags for use as menu containers.
+			 *                    Default is array containing 'div' and 'nav'.
+			 */
+			$allowed_tags = apply_filters( 'wp_nav_menu_container_allowedtags', array( 'div', 'nav' ) );
+			if ( is_string( $args['container'] ) && in_array( $args['container'], $allowed_tags, true ) ) {
+				$show_container   = true;
+				$class            = $args['container_class'] ? ' class="menu-fallback-container ' . esc_attr( $args['container_class'] ) . '"' : ' class="menu-fallback-container"';
+				$id               = $args['container_id'] ? ' id="' . esc_attr( $args['container_id'] ) . '"' : '';
+				$fallback_output .= '<' . $args['container'] . $id . $class . '>';
+			}
+		}
+
+		// The fallback menu.
+		$class            = $args['menu_class'] ? ' class="menu-fallback-menu ' . esc_attr( $args['menu_class'] ) . '"' : ' class="menu-fallback-menu"';
+		$id               = $args['menu_id'] ? ' id="' . esc_attr( $args['menu_id'] ) . '"' : '';
+		$fallback_output .= '<ul' . $id . $class . '>';
+		$fallback_output .= '<li class="nav-item"><a href="' . esc_url( admin_url( 'nav-menus.php' ) ) . '" class="nav-link" title="' . esc_attr__( 'Add a menu', 'wp-bootstrap-navwalker' ) . '">' . esc_html__( 'Add a menu', 'wp-bootstrap-navwalker' ) . '</a></li>';
+		$fallback_output .= '</ul>';
+
+		// Menu container closing tag.
+		if ( $show_container ) {
+			$fallback_output .= '</' . $args['container'] . '>';
+		}
+
+		// If $args has 'echo' key and it's true echo, otherwise return.
+		if ( array_key_exists( 'echo', $args ) && $args['echo'] ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $fallback_output;
+		} else {
+			return $fallback_output;
+		}
+	}
+
+	/**
+	 * Filter to ensure the items_wrap argument contains microdata.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param  array $args The nav instance arguments.
+	 * @return array $args The altered nav instance arguments.
+	 */
+	public function add_schema_to_navbar_ul( $args ) {
+		if ( isset( $args['items_wrap'] ) ) {
+			$wrap = $args['items_wrap'];
+			if ( strpos( $wrap, 'SiteNavigationElement' ) === false ) {
+				$args['items_wrap'] = preg_replace( '/(>).*>?\%3\$s/', ' itemscope itemtype="http://www.schema.org/SiteNavigationElement"$0', $wrap );
+			}
+		}
+		return $args;
+	}
+
+	/**
+	 * Finds any custom linkmod or icon classes and store in their holder
+	 * arrays then remove them from the main classes array.
+	 *
+	 * Supported linkmods: .disabled, .dropdown-header, .dropdown-divider, .sr-only
+	 * Supported iconsets: Font Awesome 4/5, Glypicons
+	 *
+	 * NOTE: This accepts the linkmod and icon arrays by reference.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array   $classes         An array of classes currently assigned to the item.
+	 * @param array   $linkmod_classes An array to hold linkmod classes.
+	 * @param array   $icon_classes    An array to hold icon classes.
+	 * @param integer $depth           An integer holding current depth level.
+	 * @return array  $classes A maybe modified array of classnames.
+	 */
+	private function separate_linkmods_and_icons_from_classes( $classes, &$linkmod_classes, &$icon_classes, $depth ) {
+		// Loop through $classes array to find linkmod or icon classes.
+		foreach ( $classes as $key => $class ) {
+			/*
+				* If any special classes are found, store the class in it's
+				* holder array and and unset the item from $classes.
+				*/
+			if ( preg_match( '/^disabled|^sr-only/i', $class ) ) {
+				// Test for .disabled or .sr-only classes.
+				$linkmod_classes[] = $class;
+				unset( $classes[ $key ] );
+			} elseif ( preg_match( '/^dropdown-header|^dropdown-divider|^dropdown-item-text/i', $class ) && $depth > 0 ) {
+				/*
+					* Test for .dropdown-header or .dropdown-divider and a
+					* depth greater than 0 - IE inside a dropdown.
+					*/
+				$linkmod_classes[] = $class;
+				unset( $classes[ $key ] );
+			} elseif ( preg_match( '/^fa-(\S*)?|^fa(s|r|l|b)?(\s?)?$/i', $class ) ) {
+				// Font Awesome.
+				$icon_classes[] = $class;
+				unset( $classes[ $key ] );
+			} elseif ( preg_match( '/^glyphicon-(\S*)?|^glyphicon(\s?)$/i', $class ) ) {
+				// Glyphicons.
+				$icon_classes[] = $class;
+				unset( $classes[ $key ] );
+			}
+		}
+
+		return $classes;
+	}
+
+	/**
+	 * Returns a string containing a linkmod type and updates the $atts
+	 * array accordingly depending on the decided.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array $linkmod_classes Array of any link modifier classes.
+	 * @return string Empty for default, a linkmod type string otherwise.
+	 */
+	private function get_linkmod_type( $linkmod_classes = array() ) {
+		$linkmod_type = '';
+		// Loop through array of linkmod classes to handle their $atts.
+		if ( ! empty( $linkmod_classes ) ) {
+			foreach ( $linkmod_classes as $link_class ) {
+				if ( ! empty( $link_class ) ) {
+
+					// Check for special class types and set a flag for them.
+					if ( 'dropdown-header' === $link_class ) {
+						$linkmod_type = 'dropdown-header';
+					} elseif ( 'dropdown-divider' === $link_class ) {
+						$linkmod_type = 'dropdown-divider';
+					} elseif ( 'dropdown-item-text' === $link_class ) {
+						$linkmod_type = 'dropdown-item-text';
+					}
+				}
+			}
+		}
+		return $linkmod_type;
+	}
+
+	/**
+	 * Updates the attributes of a nav item depending on the limkmod classes.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param array $atts            Array of atts for the current link in nav item.
+	 * @param array $linkmod_classes An array of classes that modify link or nav item behaviors or displays.
+	 * @return array Maybe updated array of attributes for item.
+	 */
+	private function update_atts_for_linkmod_type( $atts = array(), $linkmod_classes = array() ) {
+		if ( ! empty( $linkmod_classes ) ) {
+			foreach ( $linkmod_classes as $link_class ) {
+				if ( ! empty( $link_class ) ) {
+					/*
+						* Update $atts with a space and the extra classname
+						* so long as it's not a sr-only class.
+						*/
+					if ( 'sr-only' !== $link_class ) {
+						$atts['class'] .= ' ' . esc_attr( $link_class );
+					}
+					// Check for special class types we need additional handling for.
+					if ( 'disabled' === $link_class ) {
+						// Convert link to '#' and unset open targets.
+						$atts['href'] = '#';
+						unset( $atts['target'] );
+					} elseif ( 'dropdown-header' === $link_class || 'dropdown-divider' === $link_class || 'dropdown-item-text' === $link_class ) {
+						// Store a type flag and unset href and target.
+						unset( $atts['href'] );
+						unset( $atts['target'] );
+					}
+				}
+			}
+		}
+		return $atts;
+	}
+
+	/**
+	 * Wraps the passed text in a screen reader only class.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $text The string of text to be wrapped in a screen reader class.
+	 * @return string The string wrapped in a span with the class.
+	 */
+	private function wrap_for_screen_reader( $text = '' ) {
+		if ( $text ) {
+			$text = '<span class="sr-only">' . $text . '</span>';
+		}
+		return $text;
+	}
+
+	/**
+	 * Returns the correct opening element and attributes for a linkmod.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $linkmod_type A string containing a linkmod type flag.
+	 * @param string $attributes   A string of attributes to add to the element.
+	 * @return string A string with the opening tag for the element with attribibutes added.
+	 */
+	private function linkmod_element_open( $linkmod_type, $attributes = '' ) {
+		$output = '';
+		if ( 'dropdown-item-text' === $linkmod_type ) {
+			$output .= '<span class="dropdown-item-text"' . $attributes . '>';
+		} elseif ( 'dropdown-header' === $linkmod_type ) {
+			/*
+				* For a header use a span with the .h6 class instead of a real
+				* header tag so that it doesn't confuse screen readers.
+				*/
+			$output .= '<span class="dropdown-header h6"' . $attributes . '>';
+		} elseif ( 'dropdown-divider' === $linkmod_type ) {
+			// This is a divider.
+			$output .= '<div class="dropdown-divider"' . $attributes . '>';
+		}
+		return $output;
+	}
+
+	/**
+	 * Returns the correct closing tag for the linkmod element.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param string $linkmod_type A string containing a special linkmod type.
+	 * @return string A string with the closing tag for this linkmod type.
+	 */
+	private function linkmod_element_close( $linkmod_type ) {
+		$output = '';
+		if ( 'dropdown-header' === $linkmod_type || 'dropdown-item-text' === $linkmod_type ) {
+			/*
+				* For a header use a span with the .h6 class instead of a real
+				* header tag so that it doesn't confuse screen readers.
+				*/
+			$output .= '</span>';
+		} elseif ( 'dropdown-divider' === $linkmod_type ) {
+			// This is a divider.
+			$output .= '</div>';
+		}
+		return $output;
+	}
+
+	/**
+	 * Flattens a multidimensional array to a simple array.
+	 *
+	 * @param array $array A multidimensional array.
+	 * @return array A simple array.
+	 */
+	public function flatten( $array ) {
+		$result = array();
+		foreach ( $array as $element ) {
+			if ( is_array( $element ) ) {
+				array_push( $result, ...$this->flatten( $element ) );
+			} else {
+				$result[] = $element;
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Retrieves the Bootstrap version to use.
+	 *
+	 * @param WP_Nav_Menu_Args $args An object of `wp_nav_menu()` arguments.
+	 * @return int Major Bootstrap version
+	 */
+	private function get_bs_version( $args ) {
+		if ( property_exists( $args, 'bs_version' ) && 5 === (int) $args->bs_version ) {
+			return (int) $args->bs_version;
+		}
+		return $this->bs_version;
+	}
+}

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -259,11 +259,11 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 					$infix = '-bs';
 				}
 
-				$atts['href']              = '#';
-				$atts["data$infix-toggle"] = 'dropdown';
-				$atts['aria-expanded']     = 'false';
-				$atts['class']             = 'dropdown-toggle nav-link';
-				$atts['id']                = 'menu-item-dropdown-' . $item->ID;
+				$atts['href']                = '#';
+				$atts[ "data$infix-toggle" ] = 'dropdown';
+				$atts['aria-expanded']       = 'false';
+				$atts['class']               = 'dropdown-toggle nav-link';
+				$atts['id']                  = 'menu-item-dropdown-' . $item->ID;
 
 				$atts['class'] .= ( $is_active && 5 === $bs_version ) ? ' active' : '';
 			} else {

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -236,7 +236,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			}
 
 			// If the item has_children add atts to <a>.
-			if ( $this->has_children && 0 === $depth ) {
+			if ( $is_dropdown ) {
 				$atts['href']          = '#';
 				$atts['data-toggle']   = 'dropdown';
 				$atts['aria-expanded'] = 'false';

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -156,7 +156,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			$is_dropdown = false;
 			if ( $this->has_children && 1 !== $args->depth ) {
 				$is_dropdown = true;
-				if ( $depth >= $args->depth - 1 && $args->depth !== 0 ) {
+				if ( $depth >= $args->depth - 1 && 0 !== $args->depth ) {
 					$is_dropdown = false;
 				}
 			}
@@ -251,7 +251,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
 				if ( $is_dropdown_item ) {
-					$atts['class'] = 'dropdown-item';
+					$atts['class']  = 'dropdown-item';
 					$atts['class'] .= $is_active ? ' active' : '';
 				} else {
 					$atts['class'] = 'nav-link';

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -152,6 +152,30 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			// Join any icon classes plucked from $classes into a string.
 			$icon_class_string = join( ' ', $icon_classes );
 
+			// Whether the current item is a dropdown.
+			$is_dropdown = false;
+			if ( $this->has_children && 1 !== $args->depth ) {
+				$is_dropdown = true;
+				if ( $depth >= $args->depth - 1 && $args->depth !== 0 ) {
+					$is_dropdown = false;
+				}
+			}
+
+			// Whether the current item is a dropdown item.
+			$is_dropdown_item = false;
+			if ( ! ( $this->has_children && 0 === $depth ) && $depth > 0 ) {
+				$is_dropdown_item = true;
+			}
+
+			// Whether the current item is active or the item is an ancestor of
+			// the current item.
+			$is_active = false;
+			if ( $item->current || $item->current_item_ancestor ) {
+				if ( ! ( $item->current_item_ancestor && 1 === $args->depth ) ) {
+					$is_active = true;
+				}
+			}
+
 			/**
 			 * Filters the arguments for a single nav menu item.
 			 *
@@ -165,11 +189,12 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 			 */
 			$args = apply_filters( 'nav_menu_item_args', $args, $item, $depth );
 
-			// Add .dropdown or .active classes where they are needed.
-			if ( $this->has_children ) {
+			if ( $is_dropdown ) {
 				$classes[] = 'dropdown';
 			}
-			if ( in_array( 'current-menu-item', $classes, true ) || in_array( 'current-menu-parent', $classes, true ) ) {
+
+			if ( $is_active && ! $is_dropdown_item ) {
+				// For dropdown items the .active class is set on the a tag.
 				$classes[] = 'active';
 			}
 
@@ -226,6 +251,7 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
 				if ( $depth > 0 ) {
 					$atts['class'] = 'dropdown-item';
+					$atts['class'] .= $is_active ? ' active' : '';
 				} else {
 					$atts['class'] = 'nav-link';
 				}

--- a/class-wp-bootstrap-navwalker.php
+++ b/class-wp-bootstrap-navwalker.php
@@ -248,8 +248,9 @@ if ( ! class_exists( 'WP_Bootstrap_Navwalker' ) ) :
 				}
 
 				$atts['href'] = ! empty( $item->url ) ? $item->url : '#';
+
 				// For items in dropdowns use .dropdown-item instead of .nav-link.
-				if ( $depth > 0 ) {
+				if ( $is_dropdown_item ) {
 					$atts['class'] = 'dropdown-item';
 					$atts['class'] .= $is_active ? ' active' : '';
 				} else {


### PR DESCRIPTION
This PR adds basic Bootstrap 5 support to the walker.

Fixes #528

#### Changes proposed in this Pull Request:

* Adds the possibility to request Bootstrap 5 markup via the arguments passed to the `wp_nav_menu()` function.
* Adds the bs infix to data attributes if Bootstrap 5 markup is requested.
* Adds the `.active` class to the a element instead of the li element if Bootstrap 5 markup is requested.

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
Add basic Bootstrap 5 support

#### Notes:
* Unit tests are missing - but I suggest to add them later in another PR
* This PR builds upon #530
* Todo:
  * add support for `.visually-hidden`

#### Related issues and PRs:
#499, #513, #500